### PR TITLE
Fix Floating point exception 

### DIFF
--- a/README.SOWFA
+++ b/README.SOWFA
@@ -6,7 +6,7 @@ distribution. Please see the included OpenFOAM readme file
 ("README.OpenFOAM") and the GPL licence information ("COPYING"). Access
 to and use of SOWPA imposes obligations on the user, as set forth in the 
 NWTC Design Codes DATA USE DISCLAIMER AGREEMENT that can be found at
-<http://wind.nrel.gov/designcodes/disclaimer.html>.
+<https://nwtc.nrel.gov/disclaimer>.
 
 
 
@@ -22,16 +22,16 @@ A.  Solvers
     2.  ABLTerrainSolver - Basically the same as ABLSolver, but the planar
         averaging done in ABLSolver is replaced with time averaging since
         planar averaging does not make sense for terrain.
-    3.  windPlantSolver - A specialized version of ABLTerrainSolver for
+    3.  windPlantSolver.<X> - A specialized version of ABLTerrainSolver for
         performing LES of wind plant flow.  It includes the ability to
         include actuator line turbine models with local grid refinement
-        around the turbine.
-    4.  windPlantSolverFAST - Like windPlantSolver, but the actuator
-        line turbine model is coupled to NREL's FAST aeroelastic and turbine
-        system dynamics code.
-    5.  pisoFoamTurbine - OpenFOAM's standard pisoFoam solver, but with the
-        actuator line model included.
-    6.  turbineTestHarness - A simple code coupled to the actuator line model
+        around the turbine. The <X> corresponds to the turbine type and is
+        "ALM", "ADM", "ALMAdvanced", or "ALMAdvancedFASTv8".
+    5.  pisoFoamTurbine.<X> - OpenFOAM's standard pisoFoam solver, but with the
+        actuator turbine models included.  This is useful for simple cases, or
+        for cases where atmospheric effects are not important, like turbines
+        in wind tunnels.
+    6.  turbineTestHarness.<X> - A simple code coupled to the actuator line model
         that allows you to quickly test a actuator line model setup.  It mimics
         pisoFoam, but the governing equations are not actually solved, the
         velocity field is constant through the domain, but can change as a 
@@ -72,18 +72,31 @@ C.  Libraries
             *inflow temperature - an inflow temperature condition that 
              attempts to recreate a typical ABL potential temperature
              profile
-    2.  incompressible LES models - Contains a modified version of the 
-        OpenFOAM standard dynamic Lagrangian model of Meneveau et al. but
-        that writes out the Cs field.  Also, contains a modified version of
-        that same model that clips the Cs field.
-    3.  turbineModels - Contains the actuator line turbine model similar
-        to that outlined by Sorensen and Shen (2002).
-    4.  openfast - A version of NREL's FAST code (see 
-        http://wind.nrel.gov/designcodes/simulators/fast/) meant for
-        coupling with the windPlantPisoSolverFAST solver.
-    5.  fastturb - A version of the actuator line turbine model that
-        is coupled with NREL's FAST aeroelastic and turbine system
-        dynamics code.
+            *time varying mapped fixed value with organized random
+             perturbations.  Useful for taking inflow from a mesoscale
+             weather model and applying temperature perturbations to
+             create resolved-scale turbulence.
+    2.  incompressible LES models - 
+            *a modified version of OpenFOAM standard Smagorinsky model
+             with Pr_t sensitization to atmospheric stability.
+            *Deardorff-Lilly one-equation model.
+            *Kosovic nonlinear backscatter anisotropy one-equation model.
+            *a modified version of OpenFOAM standard dynamic 
+             Lagrangian model of Meneveau et al. but  that writes out
+             the Cs field.  Also, contains a modified version of
+             that same model that clips the Cs field.
+    3.  turbineModelsStandard - Contains the actuator line/disk turbine 
+        models similar to that outlined by Sorensen and Shen (2002).
+    4.  turbineModelsFASTv8 - Actuator line model with coupling to FAST 8
+        (see http://wind.nrel.gov/designcodes/simulators/fast/) meant for
+        coupling with the windPlantSolver.ALMAdvancedFASTv8 solver.
+    5.  postProcessing - Function objects to simulate the sampling patterns
+        of scanning lidar.  Useful for simulating lidar to understand its
+        capabilities and limitations. 
+    6.  fileFormats - Adds a structured VTK file format that cuts down
+        on file size by greatly eliminating the write out of x,y,z points.
+    7.  sampling - Adds a sampling set that defines an annulus.  Useful
+        for sampling annuli in rotor plane to see blade-local flow.
 
 
 
@@ -92,7 +105,9 @@ Installation/Compiling:
 The included codes work only with the OpenFOAM CFD Toolbox.  OpenFOAM has
 not been distributed with the SOWFA package.  Please visit www.openfoam.com
 to download and install OpenFOAM.  This release of SOWFA is known to work
-with OpenFOAM-2.0.x, but should work with versions up to 2.3.x
+with up to OpenFOAM-2.4.x.  Making SOWFA work with versions 3.0 and higher
+may come in the near future.
+
 
 Once OpenFOAM is installed and SOWFA downloaded, please follow these steps:
 1.  Put the SOWFA directory where you want it.  This directory will remain
@@ -121,38 +136,49 @@ Once OpenFOAM is installed and SOWFA downloaded, please follow these steps:
 Running Tutorials:
 Tutorial example cases are provide for each solver. The tutorials are
 as follows
+1.  example.ABL.flatTerrain.neutral
+    example.ABL.flatTerrain.unstable
+    example.ABL.flatTerrain.stable
+    -Example cases for computing flat-terrain laterally periodic precursor
+     atmospheric large-eddy simulations under the full range of stability.
+    -Uses ABLSolver
 
-1.  precursorABL - An example case of how to perform an atmospheric
-    boundary layer large-eddy simulation (without turbines).  This
-    will generate turbulent fields that can be used in wind plant
-    simulations.
+2.  example.ALM
+    example.ALMAdvanced
+    example.ADM
+    -Example cases that use the actuator turbine models using the 
+     windPlantSolver.<X> solvers.  These cases assume that a precursor
+     case has been run to generate inflow velocity and temperature 
+     data.  Because the inflow data is large, we did not include it here.
+    -Uses windPlantSolver.ALM
+          windPlantSolver.ADM
+          windPlantSolver.ALMAdvanced
 
-2.  windPlant - An example of how to use windPlantPisoSolver with
-    a farm of NREL 5MW turbines.
+3.  example.NREL5MW.ALMAdvancedFAST8
+    -Example case that uses the FAST 8 coupled actuator line turbine model.
+     The example is a single rotor in uniform, non-turbulent inflow.
+    -Uses pisoFoamTurbine.ALMAdvancedFAST8 
+ 
+4.  example.UAE_PhaseVI.ALMAdvanced/
+    -A case with the setup of the NREL Unsteady Aerodynamics Experiment
+     Phase VI, in the NASA Ames 80'x120' wind tunnel.
+    -Uses pisoFoamTurbine.ALMAdvanced
 
-3.  windPlantFAST - Like the windPlant example but for use of the
-    FAST-coupled windPlantPisoSolverFAST.
+5.  example.mesoscaleInfluence.SWiFTsiteLubbock.11Nov2013Diurnal
+    -An example of using mesoscale influence to drive the atmospheric
+     boundary layer LES.  This case is driven by WRF model output
+     for the DOE/Sandia Scaled Wind Farm Technology (SWiFT) site in 
+     Lubbock, Texas.  The terrain is flat with laterally periodic
+     boundaries in this example.  The case has enough WRF output
+     contained in the "forcing" directory to simulate two diurnal
+     cycles starting November 11, 2013 at 00:00:00 UTC.   
 
 To run a tutorial, change to that tutorial directory and run the
-Allrun script contained in the directory by entering "./Allrun".  View
-the Allrun script to understand the basic use of the code. To return
-to the original state, run the Allclean script by entering "./Allclean".
+"runscript.preprocess" script to set up the mesh, etc.  Then run the
+"runscript.solve.1" script to run the solver.
 
-These are very basic tutorials meant to familiarize the user with the
+These are basic tutorials meant to familiarize the user with the
 general file structure of a case and the various input files.  They
-are meant to run on a small amount of processors, but will not
-generate very meaningful results as the grid resolution is extremely
-coarse.  The turbine models use a Gaussian projection (see the
-"epsilon" variable in the constant/turbineArrayProperties file) that
-should be set to at least twice the local grid cell width.  For these
-examples, epsilon is set to a realistic value for performing true
-LES, but is much less than twice the local grid cell width of these
-very coarse grids.  The precursorABL tutorial uses a periodic mesh,
-which is what we do in running a "real" precursor simulation. The
-wind plant tutorials also use a periodic mesh, but in actuality, we
-feed data saved from the precursor into the wind plant domain and
-have outflow boundaries elsewhere.  We did not show this in these
-tutorials since the precursorABL simulation is too coarse to create
-meaningful inflow data for the windPlant simulations.  We leave it to
-the user to experiment with this.
+can be run on a small amount of processors with coarse meshes, but if 
+that is done, they will generate poor results. 
 

--- a/src/turbineModels/turbineModelsFASTv8/horizontalAxisWindTurbinesALMfastv8/horizontalAxisWindTurbinesALMfastv8.C
+++ b/src/turbineModels/turbineModelsFASTv8/horizontalAxisWindTurbinesALMfastv8/horizontalAxisWindTurbinesALMfastv8.C
@@ -1558,12 +1558,9 @@ void horizontalAxisWindTurbinesALMfastv8::getPositions()
        bladePoint1 /= mag(bladePoint1);
 
      //Info << "bladePoint1 = " << bladePoint1 << endl;
-     //Info << "bladePoint1Old = " << bladePoint1Old << endl;
-
-     // If bladePoint1 and bladePoint1Old are equal, the acos function can throw a Floating Point Exception
-       scalar cosPhi = (bladePoint1 & bladePoint1Old) / (mag(bladePoint1) * mag(bladePoint1Old) + Foam::VSMALL);
-     // Enforce bounding between -1 and 1   
-       scalar deltaAzimuth = acos(min(max(cosPhi, -1), 1));   
+     //Info << "bladePoint1Old = " << bladePoint1Old << endl; 
+	   
+      scalar deltaAzimuth = Foam::acos(Foam::max(-1.0, Foam::min( (bladePoint1 & bladePoint1Old) / (mag(bladePoint1) * mag(bladePoint1Old)),1.0)));
      //Info << "deltaAzimuth = " << deltaAzimuth / degRad << endl;
 
      //Info << "dt = " << dt << endl;

--- a/src/turbineModels/turbineModelsFASTv8/horizontalAxisWindTurbinesALMfastv8/horizontalAxisWindTurbinesALMfastv8.C
+++ b/src/turbineModels/turbineModelsFASTv8/horizontalAxisWindTurbinesALMfastv8/horizontalAxisWindTurbinesALMfastv8.C
@@ -1560,8 +1560,10 @@ void horizontalAxisWindTurbinesALMfastv8::getPositions()
      //Info << "bladePoint1 = " << bladePoint1 << endl;
      //Info << "bladePoint1Old = " << bladePoint1Old << endl;
 
-       scalar deltaAzimuth = Foam::acos((bladePoint1 & bladePoint1Old) / (mag(bladePoint1) * mag(bladePoint1Old)));
-
+     // If bladePoint1 and bladePoint1Old are equal, the acos function can throw a Floating Point Exception
+       scalar cosPhi = (bladePoint1 & bladePoint1Old) / (mag(bladePoint1) * mag(bladePoint1Old) + Foam::VSMALL);
+     // Enforce bounding between -1 and 1   
+       scalar deltaAzimuth = acos(min(max(cosPhi, -1), 1));   
      //Info << "deltaAzimuth = " << deltaAzimuth / degRad << endl;
 
      //Info << "dt = " << dt << endl;


### PR DESCRIPTION
There is a floating point exception on horizontalAxisWindTurbinesALMfastv8.C, line 1563, whenever the vectors bladePoint1 and bladePoint1Old are equal, because it's trying to calculate the acos of a value slightly higher than 1 (due to numerical rounding issues)

I enforce the argument of acos to be between -1 and 1. 
This issue is solved in the openFast branch, but not in this one, and I use the same solution. 