### PR TITLE
Improved correlation calculations

### DIFF
--- a/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedOpenFAST/computeAverageFields.H
+++ b/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedOpenFAST/computeAverageFields.H
@@ -1,7 +1,6 @@
 {
-    volVectorField uPrime = U;
-    volScalarField TPrime = T;
-
+    //volVectorField uPrime = U;
+    //volScalarField TPrime = T;
     volSymmTensorField R = 1.0*turbulence->R();
     volVectorField q = -kappat * fvc::grad(T);
     volScalarField nuSGS = 1.0*turbulence->nut();
@@ -9,7 +8,7 @@
     volScalarField epsilonSGS = 1.0*turbulence->epsilon();
 
 
-    // Compute the running time averages of the fields and then get the fluctuation.
+    // Compute the running time averages of the fields
     if (runTime.value() >= avgStartTime)
     {
         UAvg = (UAvg * avgTimeSum) + (runTime.deltaT().value() * U);
@@ -20,6 +19,9 @@
         nuSGSmean = (nuSGSmean * avgTimeSum) + (runTime.deltaT().value() * nuSGS);
         kSGSmean = (kSGSmean * avgTimeSum) + (runTime.deltaT().value() * kSGS);
         epsilonSGSmean = (epsilonSGSmean * avgTimeSum) + (runTime.deltaT().value() * epsilonSGS);
+        UUAvg = (UUAvg * avgTimeSum) + (runTime.deltaT().value() * Foam::sqr(U));
+        TTAvg = (TTAvg * avgTimeSum) + (runTime.deltaT().value() * Foam::sqr(T));
+        UTAvg = (UTAvg * avgTimeSum) + (runTime.deltaT().value() * T*U);
 
         avgTimeSum += runTime.deltaT().value();
         Info << "avgTimeSum = " << avgTimeSum << endl;
@@ -32,36 +34,45 @@
         nuSGSmean = nuSGSmean / avgTimeSum;
         kSGSmean = kSGSmean / avgTimeSum;
         epsilonSGSmean = epsilonSGSmean / avgTimeSum;
-    }
+        UUAvg = UUAvg / avgTimeSum;
+        TTAvg = TTAvg / avgTimeSum;
+        UTAvg = UTAvg / avgTimeSum;
 
-    // Compute the running time averages of the correlation fields.
-    if (runTime.value() >= corrStartTime)
-    {
-        uPrime = U - UAvg;
-        TPrime = T - TAvg;
-
-        uuPrime2 = (uuPrime2 * corrTimeSum) + (runTime.deltaT().value() * Foam::sqr(uPrime));
-        uTPrime2 = (uTPrime2 * corrTimeSum) + (runTime.deltaT().value() * TPrime * uPrime);
-        TTPrime2 = (TTPrime2 * corrTimeSum) + (runTime.deltaT().value() * Foam::sqr(TPrime));
-
-        corrTimeSum += runTime.deltaT().value();
-        Info << "corrTimeSum = " << corrTimeSum << endl;
-
-        uuPrime2 = uuPrime2 / corrTimeSum;
-        uTPrime2 = uTPrime2 / corrTimeSum;
-        TTPrime2 = TTPrime2 / corrTimeSum;
+        uuPrime2 = UUAvg - Foam::sqr(UAvg);       // calculate time-averaged u'u' from instantaneous UUAvg & UAvg, without needing long-term UAvg
+        uTPrime2 = UTAvg - (TAvg * UAvg);
+        TTPrime2 = TTAvg - Foam::sqr(TAvg);
 
         forAll(uRMS,cellI)
         {
-            uRMS[cellI].x() = Foam::sqrt(uuPrime2[cellI].xx());
-            uRMS[cellI].y() = Foam::sqrt(uuPrime2[cellI].yy());
-            uRMS[cellI].z() = Foam::sqrt(uuPrime2[cellI].zz());
+            uRMS[cellI].x() = Foam::sqrt(Foam::mag(uuPrime2[cellI].xx())); // Foam::mag ensures won't crash with sqrt(-value) floating point exception
+            uRMS[cellI].y() = Foam::sqrt(Foam::mag(uuPrime2[cellI].yy()));
+            uRMS[cellI].z() = Foam::sqrt(Foam::mag(uuPrime2[cellI].zz()));
         }
-        TRMS = Foam::sqrt(TTPrime2);
+        TRMS = Foam::sqrt(Foam::mag(TTPrime2));
 
         forAll(kResolved,cellI)
         {
             kResolved[cellI] = 0.5 * (uuPrime2[cellI].xx() + uuPrime2[cellI].yy() + uuPrime2[cellI].zz());
         }
     }
+
+/*  corrStartTime, corrTimeSum no longer used
+    // Compute the running time history of uPrime, Tprime
+    if (runTime.value() >= corrStartTime)
+    {
+        //uPrime = U - UAvg; // user should calculate themselves from long-term UAvg in post-processing
+        //TPrime = T - TAvg; // user should calculate themselves from long-term TAvg in post-processing
+
+        //uuPrime2 = (uuPrime2 * corrTimeSum) + (runTime.deltaT().value() * Foam::sqr(uPrime)); // previous version of uuPrime2
+        //uTPrime2 = (uTPrime2 * corrTimeSum) + (runTime.deltaT().value() * TPrime * uPrime);   // previous version of uTPrime2
+        //TTPrime2 = (TTPrime2 * corrTimeSum) + (runTime.deltaT().value() * Foam::sqr(TPrime)); // previous version of TTPrime2
+
+        corrTimeSum += runTime.deltaT().value();
+        Info << "corrTimeSum = " << corrTimeSum << endl;
+
+        //uuPrime2 = uuPrime2 / corrTimeSum; // finalizing previous versions of uuPrime2, uTPrime2, TTPrime2
+        //uTPrime2 = uTPrime2 / corrTimeSum;
+        //TTPrime2 = TTPrime2 / corrTimeSum;
+    }
+*/
 }

--- a/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedOpenFAST/createAverageFields.H
+++ b/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedOpenFAST/createAverageFields.H
@@ -94,6 +94,56 @@
         dimensionedScalar("TRMS",dimensionSet(0, 0, 0, 1, 0, 0, 0),0.0)
     );
 
+
+    // Create & read in the time-averaged velocity*velocity tensor field: for uuPrime2 calculations
+    Info<< "Creating the time-averaged velocity squared field, UUAvg..." << endl;
+    volSymmTensorField UUAvg
+    (
+        IOobject
+        (
+            "UUavg",
+            runTime.timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        dimensionedSymmTensor("UUavg",dimensionSet(0, 2, -2, 0, 0, 0, 0),symmTensor::zero)
+    );
+
+    // Create and read in initial time-averaged temperature*velocity field: for uTPrime2 calculations
+    Info << "Creating time-averaged velocity*temperature field, UTAvg..." << endl;
+    volVectorField UTAvg
+    (
+        IOobject
+        (
+            "UTAvg",
+            runTime.timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        dimensionedVector("UTAvg",dimensionSet(0, 1, -1, 1, 0, 0, 0),vector::zero)
+    );
+
+    // Create and read in the time-averaged temperature*temperature field: for TTPrime2 calculations
+    Info << "Creating time-averaged temperature*temperature field, TTAvg..." << endl;
+    volScalarField TTAvg
+    (
+        IOobject
+        (
+            "TTAvg",
+            runTime.timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        dimensionedScalar("TTAvg",dimensionSet(0, 0, 0, 2, 0, 0, 0),0.0)
+    );
+
+
     // Create the time-averaged Reynolds stress tensor field.
     Info<< "Creating the time-averaged Reynolds stress field, uuPrime2..." << endl;
     volSymmTensorField uuPrime2
@@ -251,7 +301,7 @@
         ),
         turbulence->k()
     );
- 
+
     Info<< "Creating the mean SGS turbulent kinetic energy dissipation field, kSGSMean..." << endl;
     volScalarField epsilonSGSmean
     (
@@ -270,5 +320,6 @@
 
     // Declare total averaging times for average fields and correlation fields.
     scalar avgTimeSum = max(runTime.value() - avgStartTime, 0.0);
-    scalar corrTimeSum = max(runTime.value() - corrStartTime, 0.0);
-    Info << "avgTimeSum = " << avgTimeSum << tab << "corrTimeSum = " << corrTimeSum << endl;
+    scalar corrTimeSum = max(runTime.value() - corrStartTime, 0.0); // corrStartTime and corrTimeSum no longer used
+    //Info << "avgTimeSum = " << avgTimeSum << tab << "corrTimeSum = " << corrTimeSum << endl;
+    Info << "avgTimeSum = " << avgTimeSum << endl;

--- a/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedOpenFAST/createAverageFields.H
+++ b/applications/solvers/incompressible/windEnergy/windPlantSolver.ALMAdvancedOpenFAST/createAverageFields.H
@@ -101,14 +101,14 @@
     (
         IOobject
         (
-            "UUavg",
+            "UUAvg",
             runTime.timeName(),
             mesh,
             IOobject::READ_IF_PRESENT,
             IOobject::AUTO_WRITE
         ),
         mesh,
-        dimensionedSymmTensor("UUavg",dimensionSet(0, 2, -2, 0, 0, 0, 0),symmTensor::zero)
+        dimensionedSymmTensor("UUAvg",dimensionSet(0, 2, -2, 0, 0, 0, 0),symmTensor::zero)
     );
 
     // Create and read in initial time-averaged temperature*velocity field: for uTPrime2 calculations


### PR DESCRIPTION
Improved correlation calculations for u'u', T'T', u'T' in windPlantSolver.ALMAdvancedOpenFAST
e.g. TimeAvg(u'u') = TimeAvg(UU) - TimeAvg(U)*TimeAvg(U)