### PR TITLE
Implementation of sponge layer

### DIFF
--- a/applications/solvers/incompressible/windEnergy/ABLSolver/UEqn.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/UEqn.H
@@ -1,6 +1,7 @@
     // Solve the momentum equation
 
     #include "computeCoriolisForce.H"
+    #include "computeSpongeForce.H"
 
     #include "computeBuoyancyTerm.H"
 
@@ -11,6 +12,7 @@
       + turbulence->divDevReff(U)               // momentum flux
       + fvc::div(Rwall)
       - fCoriolis                               // Coriolis force
+      - fSponge                                 // Sponge layer damping
       - SourceU                                 // mesoscale source terms
     );
 

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/computeSpongeForce.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/computeSpongeForce.H
@@ -1,0 +1,9 @@
+        // Compute the sponge layer damping force
+        if (spongeLayerType == "Rayleigh")
+        {
+            fSponge = spongeLayerViscosity * (spongeLayerReferenceVelocity - U);
+        }
+        else if (spongeLayerType == "viscous")
+        {
+            fSponge = fvc::laplacian(spongeLayerViscosity,U);
+        }

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/createFields.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/createFields.H
@@ -78,6 +78,83 @@
         dimensionedVector("fCoriolis",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
     );
 
+    // Create sponge layer viscosity field
+    Info << "Creating sponge layer viscosity field, spongeLayerViscosity..." << endl;
+    label lengthDimension;
+    if (spongeLayerType == "Rayleigh")
+    {
+        lengthDimension = 0;
+    }
+    else
+    {
+        lengthDimension = 2;
+    }
+
+    volScalarField spongeLayerViscosity
+    (
+        IOobject
+        (
+            "spongeLayerViscosity",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        dimensionedScalar("spongeLayerViscosity",dimensionSet(0, lengthDimension, -1, 0, 0, 0, 0),spongeLayerViscosityTop)
+    );
+
+    forAll(mesh.cells(),cellI)
+    {
+        scalar z = mesh.C()[cellI][upIndex];
+        spongeLayerViscosity[cellI] *= 0.5 *
+            (
+                1.0 - Foam::cos
+                    (
+                        Foam::constant::mathematical::pi *
+                        max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
+                    )
+                
+            );
+    }
+
+    forAll(spongeLayerViscosity.boundaryField(),i)
+    {
+        if ( !mesh.boundary()[i].coupled() )
+        {
+            forAll(spongeLayerViscosity.boundaryField()[i],j)
+            {
+                scalar z = mesh.boundary()[i].Cf()[j].z();
+                spongeLayerViscosity.boundaryField()[i][j] *= 0.5 *
+                    (
+                        1.0 - Foam::cos
+                            (
+                                Foam::constant::mathematical::pi *
+                                max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
+                            )
+                        
+                    );
+            }
+        }
+    }
+
+    // Create sponge layer force vector
+    Info << "Creating sponge layer force vector, fSponge..." << endl;
+    volVectorField fSponge
+    (
+        IOobject
+        (
+            "fSponge",
+            runTime.timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::NO_WRITE
+        ),
+        mesh,
+        dimensionedVector("fSponge",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
+    );
+
+
     // Create and calculate the Boussinesq density field for computing buoyancy forces
     Info << "Creating kinematic (Boussinesq) density field, rhok..." << endl;
     volScalarField rhok

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/readABLProperties.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/readABLProperties.H
@@ -197,8 +197,6 @@
 
 
 
-
-
     // PROPERTIES CONCERNING THE WAY IN WHICH PERTURBATION PRESSURE IS DEFINED
 
        // Options for defining the perturbation pressure:
@@ -243,8 +241,51 @@
 
 
      
+    // PROPERTIES CONCERNING SPONGE LAYER
+
+       // Specify the type of sponge layer to use.  The
+       // possible types are "Rayleigh", "viscous" or "none".  
+       // - The "Rayleigh" type means that the damping term is computed as nu*(u_ref-u)
+       //   The viscosity coefficient nu has dimensions of 1/s
+       // - The "viscous" type means that the damping term is computed as nu * Lapl(u)
+       //   The viscosity coefficient nu has dimensions of m**2/s
+       // - The "none" type means no damping is added
+       word spongeLayerType(ABLProperties.lookupOrDefault<word>("spongeLayerType","none"));
+       
+       // Sponge layer base height
+       scalar spongeLayerBaseHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerBaseHeight",0.0));
+
+       // Sponge layer top height
+       scalar spongeLayerTopHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerTopHeight",10000.0));
+
+       // Sponge layer viscosity at the top boundary
+       scalar spongeLayerViscosityTop(ABLProperties.lookupOrDefault<scalar>("spongeLayerViscosityTop",0.0));
 
 
+       // Create sponge layer reference velocity
+       scalar spongeLayerUx(ABLProperties.lookupOrDefault<scalar>("spongeLayerUx",0.0));
+       scalar spongeLayerUy(ABLProperties.lookupOrDefault<scalar>("spongeLayerUy",0.0));
+       vector Uref_;
+       Uref_.x() = spongeLayerUx;
+       Uref_.y() = spongeLayerUy;
+       Uref_.z() = 0.0;
+       uniformDimensionedVectorField spongeLayerReferenceVelocity
+       (
+           IOobject
+           (
+               "spongeLayerReferenceVelocity",
+               runTime.constant(),
+               mesh,
+               IOobject::NO_READ,
+               IOobject::NO_WRITE
+           ),
+           dimensionedVector("spongeLayerReferenceVelocity",dimensionSet(0, 1, -1, 0, 0, 0, 0),Uref_)
+       );
+       
+       if (spongeLayerType == "Rayleigh")
+       {
+           Info << spongeLayerReferenceVelocity << endl;
+       }
 
 
     // PROPERTIES CONCERNING GATHERING STATISTICS

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/UEqn.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/UEqn.H
@@ -1,6 +1,8 @@
     // Solve the momentum equation
+    
 
     #include "computeCoriolisForce.H"
+    #include "computeSpongeForce.H"
 
     #include "computeBuoyancyTerm.H"
 
@@ -11,6 +13,7 @@
       + turbulence->divDevReff(U)               // momentum flux
       + fvc::div(Rwall)
       - fCoriolis                               // Coriolis force
+      - fSponge                                 // Sponge layer damping
       + gradP                                   // driving pressure gradient
     );
 

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/computeSpongeForce.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/computeSpongeForce.H
@@ -1,0 +1,9 @@
+        // Compute the sponge layer damping force
+        if (spongeLayerType == "Rayleigh")
+        {
+            fSponge = spongeLayerViscosity * (spongeLayerReferenceVelocity - U);
+        }
+        else if (spongeLayerType == "viscous")
+        {
+            fSponge = fvc::laplacian(spongeLayerViscosity,U);
+        }

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/createFields.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/createFields.H
@@ -139,6 +139,83 @@
         dimensionedVector("fCoriolis",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
     );
 
+
+    // Create sponge layer viscosity field
+    Info << "Creating sponge layer viscosity field, spongeLayerViscosity..." << endl;
+    label lengthDimension;
+    if (spongeLayerType == "Rayleigh")
+    {
+        lengthDimension = 0;
+    }
+    else
+    {
+        lengthDimension = 2;
+    }
+
+    volScalarField spongeLayerViscosity
+    (
+        IOobject
+        (
+            "spongeLayerViscosity",
+            runTime.timeName(),
+            mesh,
+            IOobject::NO_READ,
+            IOobject::AUTO_WRITE
+        ),
+        mesh,
+        dimensionedScalar("spongeLayerViscosity",dimensionSet(0, lengthDimension, -1, 0, 0, 0, 0),spongeLayerViscosityTop)
+    );
+
+    forAll(mesh.cells(),cellI)
+    {
+        scalar z = mesh.C()[cellI][upIndex];
+        spongeLayerViscosity[cellI] *= 0.5 *
+            (
+                1.0 - Foam::cos
+                    (
+                        Foam::constant::mathematical::pi *
+                        max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
+                    )
+                
+            );
+    }
+
+    forAll(spongeLayerViscosity.boundaryField(),i)
+    {
+        if ( !mesh.boundary()[i].coupled() )
+        {
+            forAll(spongeLayerViscosity.boundaryField()[i],j)
+            {
+                scalar z = mesh.boundary()[i].Cf()[j].z();
+                spongeLayerViscosity.boundaryField()[i][j] *= 0.5 *
+                    (
+                        1.0 - Foam::cos
+                            (
+                                Foam::constant::mathematical::pi *
+                                max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
+                            )
+                        
+                    );
+            }
+        }
+    }
+
+    // Create sponge layer force vector
+    Info << "Creating sponge layer force vector, fSponge..." << endl;
+    volVectorField fSponge
+    (
+        IOobject
+        (
+            "fSponge",
+            runTime.timeName(),
+            mesh,
+            IOobject::READ_IF_PRESENT,
+            IOobject::NO_WRITE
+        ),
+        mesh,
+        dimensionedVector("fSponge",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
+    );
+
     // Create and calculate the Boussinesq density field for computing buoyancy forces
     Info << "Creating kinematic (Boussinesq) density field, rhok..." << endl;
     volScalarField rhok

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/readABLProperties.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/readABLProperties.H
@@ -102,6 +102,51 @@
        Info << Omega << endl;       
 
 
+    // PROPERTIES CONCERNING SPONGE LAYER
+
+       // Specify the type of sponge layer to use.  The
+       // possible types are "Rayleigh", "viscous" or "none".  
+       // - The "Rayleigh" type means that the damping term is computed as nu*(u_ref-u)
+       //   The viscosity coefficient nu has dimensions of 1/s
+       // - The "viscous" type means that the damping term is computed as nu * Lapl(u)
+       //   The viscosity coefficient nu has dimensions of m**2/s
+       // - The "none" type means no damping is added
+       word spongeLayerType(ABLProperties.lookupOrDefault<word>("spongeLayerType","none"));
+       
+       // Sponge layer base height
+       scalar spongeLayerBaseHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerBaseHeight",0.0));
+
+       // Sponge layer top height
+       scalar spongeLayerTopHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerTopHeight",10000.0));
+
+       // Sponge layer viscosity at the top boundary
+       scalar spongeLayerViscosityTop(ABLProperties.lookupOrDefault<scalar>("spongeLayerViscosityTop",0.0));
+
+
+       // Create sponge layer reference velocity
+       scalar spongeLayerUx(ABLProperties.lookupOrDefault<scalar>("spongeLayerUx",0.0));
+       scalar spongeLayerUy(ABLProperties.lookupOrDefault<scalar>("spongeLayerUy",0.0));
+       vector Uref_;
+       Uref_.x() = spongeLayerUx;
+       Uref_.y() = spongeLayerUy;
+       Uref_.z() = 0.0;
+       uniformDimensionedVectorField spongeLayerReferenceVelocity
+       (
+           IOobject
+           (
+               "spongeLayerReferenceVelocity",
+               runTime.constant(),
+               mesh,
+               IOobject::NO_READ,
+               IOobject::NO_WRITE
+           ),
+           dimensionedVector("spongeLayerReferenceVelocity",dimensionSet(0, 1, -1, 0, 0, 0, 0),Uref_)
+       );
+       
+       if (spongeLayerType == "Rayleigh")
+       {
+           Info << spongeLayerReferenceVelocity << endl;
+       }
 
 
 


### PR DESCRIPTION
Both ABLSolver and ABLTerrainSolver are updated with the ability to add a sponge layer so as to avoid reflection of atmospheric gravity waves at the top of the numerical domain. Both Rayleigh damping and viscous damping are supported. The damping coefficient increases with height as a cosine function. Rayleigh damping takes a reference velocity (constant in space and time) as an input value.

The sponge layer is configure using the following input parameters in "constant/ABLProperties":
_// Type of sponge layer: "none" (Default), "Rayleigh" or "viscous".
spongeLayerType             "Rayleigh";
// Base height of the sponge layer (m).
spongeLayerBaseHeight       1700.0;
// Top height of the sponge layer (m).
spongeLayerTopHeight        2000.0;
// Sponge layer reference velocity (only for Rayleigh) in x direction (m/s)
spongeLayerUx               $U0Mag;
// Sponge layer reference velocity (only for Rayleigh) in y direction (m/s)
spongeLayerUy               0.0;
// Maximum viscosity attained at the top of the sponge layer
// Dimensions depend on type of damping:
// Rayleigh (1/s)
// viscous  (m^2/s)
spongeLayerViscosityTop     0.0002;_