### PR TITLE
Replace ad-hoc sponge layer implementation with more general sponge layer class

### DIFF
--- a/applications/solvers/incompressible/windEnergy/ABLSolver/ABLSolver.C
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/ABLSolver.C
@@ -57,6 +57,7 @@ Description
 #include "interpolateSplineXY.H"
 #include "interpolate2D.H"
 #include "windRoseToCartesian.H"
+#include "ABL.H"
 
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/Make/options
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/Make/options
@@ -6,12 +6,14 @@ EXE_INC = \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/fvOptions/lnInclude \
     -I$(LIB_SRC)/sampling/lnInclude \
+    -I$(SOWFA_DIR)/src/ABLForcing/lnInclude \
     -I../commonAlgorithms \
     -I../commonAlgorithms/interpolate2D \
     -I../commonAlgorithms/windRoseToCartesian
 
 
 EXE_LIBS = \
+    -L$(SOWFA_DIR)/lib/$(WM_OPTIONS) \
     -lincompressibleTransportModels \
     -lincompressibleTurbulenceModel \
     -lincompressibleRASModels \
@@ -19,4 +21,5 @@ EXE_LIBS = \
     -lfiniteVolume \
     -lmeshTools \
     -lfvOptions \
-    -lsampling
+    -lsampling \
+    -lSOWFAABLForcing 

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/UEqn.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/UEqn.H
@@ -1,9 +1,11 @@
     // Solve the momentum equation
 
     #include "computeCoriolisForce.H"
-    #include "computeSpongeForce.H"
 
     #include "computeBuoyancyTerm.H"
+
+    // Update sponge layer forcing
+    sponge.update();
 
     fvVectorMatrix UEqn
     (
@@ -12,7 +14,7 @@
       + turbulence->divDevReff(U)               // momentum flux
       + fvc::div(Rwall)
       - fCoriolis                               // Coriolis force
-      - fSponge                                 // Sponge layer damping
+      - sponge.force()                          // Sponge layer damping
       - SourceU                                 // mesoscale source terms
     );
 

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/computeSpongeForce.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/computeSpongeForce.H
@@ -1,9 +1,0 @@
-        // Compute the sponge layer damping force
-        if (spongeLayerType == "Rayleigh")
-        {
-            fSponge = spongeLayerViscosity * (spongeLayerReferenceVelocity - U);
-        }
-        else if (spongeLayerType == "viscous")
-        {
-            fSponge = fvc::laplacian(spongeLayerViscosity,U);
-        }

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/createFields.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/createFields.H
@@ -78,82 +78,9 @@
         dimensionedVector("fCoriolis",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
     );
 
-    // Create sponge layer viscosity field
-    Info << "Creating sponge layer viscosity field, spongeLayerViscosity..." << endl;
-    label lengthDimension;
-    if (spongeLayerType == "Rayleigh")
-    {
-        lengthDimension = 0;
-    }
-    else
-    {
-        lengthDimension = 2;
-    }
 
-    volScalarField spongeLayerViscosity
-    (
-        IOobject
-        (
-            "spongeLayerViscosity",
-            runTime.timeName(),
-            mesh,
-            IOobject::NO_READ,
-            IOobject::AUTO_WRITE
-        ),
-        mesh,
-        dimensionedScalar("spongeLayerViscosity",dimensionSet(0, lengthDimension, -1, 0, 0, 0, 0),spongeLayerViscosityTop)
-    );
-
-    forAll(mesh.cells(),cellI)
-    {
-        scalar z = mesh.C()[cellI][upIndex];
-        spongeLayerViscosity[cellI] *= 0.5 *
-            (
-                1.0 - Foam::cos
-                    (
-                        Foam::constant::mathematical::pi *
-                        max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
-                    )
-                
-            );
-    }
-
-    forAll(spongeLayerViscosity.boundaryField(),i)
-    {
-        if ( !mesh.boundary()[i].coupled() )
-        {
-            forAll(spongeLayerViscosity.boundaryField()[i],j)
-            {
-                scalar z = mesh.boundary()[i].Cf()[j].z();
-                spongeLayerViscosity.boundaryField()[i][j] *= 0.5 *
-                    (
-                        1.0 - Foam::cos
-                            (
-                                Foam::constant::mathematical::pi *
-                                max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
-                            )
-                        
-                    );
-            }
-        }
-    }
-
-    // Create sponge layer force vector
-    Info << "Creating sponge layer force vector, fSponge..." << endl;
-    volVectorField fSponge
-    (
-        IOobject
-        (
-            "fSponge",
-            runTime.timeName(),
-            mesh,
-            IOobject::READ_IF_PRESENT,
-            IOobject::NO_WRITE
-        ),
-        mesh,
-        dimensionedVector("fSponge",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
-    );
-
+    // Create sponge layer object
+    spongeLayer sponge("upperSponge",U);
 
     // Create and calculate the Boussinesq density field for computing buoyancy forces
     Info << "Creating kinematic (Boussinesq) density field, rhok..." << endl;

--- a/applications/solvers/incompressible/windEnergy/ABLSolver/readABLProperties.H
+++ b/applications/solvers/incompressible/windEnergy/ABLSolver/readABLProperties.H
@@ -238,56 +238,7 @@
             Info << "Pressure reference cell matrix row modification not enabled" << endl;
        }
 
-
-
      
-    // PROPERTIES CONCERNING SPONGE LAYER
-
-       // Specify the type of sponge layer to use.  The
-       // possible types are "Rayleigh", "viscous" or "none".  
-       // - The "Rayleigh" type means that the damping term is computed as nu*(u_ref-u)
-       //   The viscosity coefficient nu has dimensions of 1/s
-       // - The "viscous" type means that the damping term is computed as nu * Lapl(u)
-       //   The viscosity coefficient nu has dimensions of m**2/s
-       // - The "none" type means no damping is added
-       word spongeLayerType(ABLProperties.lookupOrDefault<word>("spongeLayerType","none"));
-       
-       // Sponge layer base height
-       scalar spongeLayerBaseHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerBaseHeight",0.0));
-
-       // Sponge layer top height
-       scalar spongeLayerTopHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerTopHeight",10000.0));
-
-       // Sponge layer viscosity at the top boundary
-       scalar spongeLayerViscosityTop(ABLProperties.lookupOrDefault<scalar>("spongeLayerViscosityTop",0.0));
-
-
-       // Create sponge layer reference velocity
-       scalar spongeLayerUx(ABLProperties.lookupOrDefault<scalar>("spongeLayerUx",0.0));
-       scalar spongeLayerUy(ABLProperties.lookupOrDefault<scalar>("spongeLayerUy",0.0));
-       vector Uref_;
-       Uref_.x() = spongeLayerUx;
-       Uref_.y() = spongeLayerUy;
-       Uref_.z() = 0.0;
-       uniformDimensionedVectorField spongeLayerReferenceVelocity
-       (
-           IOobject
-           (
-               "spongeLayerReferenceVelocity",
-               runTime.constant(),
-               mesh,
-               IOobject::NO_READ,
-               IOobject::NO_WRITE
-           ),
-           dimensionedVector("spongeLayerReferenceVelocity",dimensionSet(0, 1, -1, 0, 0, 0, 0),Uref_)
-       );
-       
-       if (spongeLayerType == "Rayleigh")
-       {
-           Info << spongeLayerReferenceVelocity << endl;
-       }
-
-
     // PROPERTIES CONCERNING GATHERING STATISTICS
 
        // Gather/write statistics?

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/ABLTerrainSolver.C
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/ABLTerrainSolver.C
@@ -55,6 +55,7 @@ Description
 #include "wallDist.H"
 #include "interpolateXY.H"
 #include "interpolateSplineXY.H"
+#include "ABL.H"
 
 
 

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/Make/options
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/Make/options
@@ -6,12 +6,14 @@ EXE_INC = \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/fvOptions/lnInclude \
     -I$(LIB_SRC)/sampling/lnInclude \
+    -I$(SOWFA_DIR)/src/ABLForcing/lnInclude \
     -I../commonAlgorithms \
     -I../commonAlgorithms/interpolate2D \
     -I../commonAlgorithms/windRoseToCartesian
 
 
 EXE_LIBS = \
+    -L$(SOWFA_DIR)/lib/$(WM_OPTIONS) \
     -lincompressibleTransportModels \
     -lincompressibleTurbulenceModel \
     -lincompressibleRASModels \
@@ -19,4 +21,5 @@ EXE_LIBS = \
     -lfiniteVolume \
     -lmeshTools \
     -lfvOptions \
-    -lsampling
+    -lsampling \
+    -lSOWFAABLForcing

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/UEqn.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/UEqn.H
@@ -2,9 +2,11 @@
     
 
     #include "computeCoriolisForce.H"
-    #include "computeSpongeForce.H"
 
     #include "computeBuoyancyTerm.H"
+
+    // Update sponge layer forcing
+    sponge.update();
 
     fvVectorMatrix UEqn
     (
@@ -13,7 +15,7 @@
       + turbulence->divDevReff(U)               // momentum flux
       + fvc::div(Rwall)
       - fCoriolis                               // Coriolis force
-      - fSponge                                 // Sponge layer damping
+      - sponge.force()                          // Sponge layer damping
       + gradP                                   // driving pressure gradient
     );
 

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/computeSpongeForce.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/computeSpongeForce.H
@@ -1,9 +1,0 @@
-        // Compute the sponge layer damping force
-        if (spongeLayerType == "Rayleigh")
-        {
-            fSponge = spongeLayerViscosity * (spongeLayerReferenceVelocity - U);
-        }
-        else if (spongeLayerType == "viscous")
-        {
-            fSponge = fvc::laplacian(spongeLayerViscosity,U);
-        }

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/createFields.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/createFields.H
@@ -140,81 +140,9 @@
     );
 
 
-    // Create sponge layer viscosity field
-    Info << "Creating sponge layer viscosity field, spongeLayerViscosity..." << endl;
-    label lengthDimension;
-    if (spongeLayerType == "Rayleigh")
-    {
-        lengthDimension = 0;
-    }
-    else
-    {
-        lengthDimension = 2;
-    }
+    // Create sponge layer object
+    spongeLayer sponge("upperSponge",U);
 
-    volScalarField spongeLayerViscosity
-    (
-        IOobject
-        (
-            "spongeLayerViscosity",
-            runTime.timeName(),
-            mesh,
-            IOobject::NO_READ,
-            IOobject::AUTO_WRITE
-        ),
-        mesh,
-        dimensionedScalar("spongeLayerViscosity",dimensionSet(0, lengthDimension, -1, 0, 0, 0, 0),spongeLayerViscosityTop)
-    );
-
-    forAll(mesh.cells(),cellI)
-    {
-        scalar z = mesh.C()[cellI][upIndex];
-        spongeLayerViscosity[cellI] *= 0.5 *
-            (
-                1.0 - Foam::cos
-                    (
-                        Foam::constant::mathematical::pi *
-                        max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
-                    )
-                
-            );
-    }
-
-    forAll(spongeLayerViscosity.boundaryField(),i)
-    {
-        if ( !mesh.boundary()[i].coupled() )
-        {
-            forAll(spongeLayerViscosity.boundaryField()[i],j)
-            {
-                scalar z = mesh.boundary()[i].Cf()[j].z();
-                spongeLayerViscosity.boundaryField()[i][j] *= 0.5 *
-                    (
-                        1.0 - Foam::cos
-                            (
-                                Foam::constant::mathematical::pi *
-                                max( (z - spongeLayerBaseHeight)/(spongeLayerTopHeight - spongeLayerBaseHeight) , 0.0 )
-                            )
-                        
-                    );
-            }
-        }
-    }
-
-    // Create sponge layer force vector
-    Info << "Creating sponge layer force vector, fSponge..." << endl;
-    volVectorField fSponge
-    (
-        IOobject
-        (
-            "fSponge",
-            runTime.timeName(),
-            mesh,
-            IOobject::READ_IF_PRESENT,
-            IOobject::NO_WRITE
-        ),
-        mesh,
-        dimensionedVector("fSponge",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
-    );
 
     // Create and calculate the Boussinesq density field for computing buoyancy forces
     Info << "Creating kinematic (Boussinesq) density field, rhok..." << endl;

--- a/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/readABLProperties.H
+++ b/applications/solvers/incompressible/windEnergy/ABLTerrainSolver/readABLProperties.H
@@ -102,54 +102,6 @@
        Info << Omega << endl;       
 
 
-    // PROPERTIES CONCERNING SPONGE LAYER
-
-       // Specify the type of sponge layer to use.  The
-       // possible types are "Rayleigh", "viscous" or "none".  
-       // - The "Rayleigh" type means that the damping term is computed as nu*(u_ref-u)
-       //   The viscosity coefficient nu has dimensions of 1/s
-       // - The "viscous" type means that the damping term is computed as nu * Lapl(u)
-       //   The viscosity coefficient nu has dimensions of m**2/s
-       // - The "none" type means no damping is added
-       word spongeLayerType(ABLProperties.lookupOrDefault<word>("spongeLayerType","none"));
-       
-       // Sponge layer base height
-       scalar spongeLayerBaseHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerBaseHeight",0.0));
-
-       // Sponge layer top height
-       scalar spongeLayerTopHeight(ABLProperties.lookupOrDefault<scalar>("spongeLayerTopHeight",10000.0));
-
-       // Sponge layer viscosity at the top boundary
-       scalar spongeLayerViscosityTop(ABLProperties.lookupOrDefault<scalar>("spongeLayerViscosityTop",0.0));
-
-
-       // Create sponge layer reference velocity
-       scalar spongeLayerUx(ABLProperties.lookupOrDefault<scalar>("spongeLayerUx",0.0));
-       scalar spongeLayerUy(ABLProperties.lookupOrDefault<scalar>("spongeLayerUy",0.0));
-       vector Uref_;
-       Uref_.x() = spongeLayerUx;
-       Uref_.y() = spongeLayerUy;
-       Uref_.z() = 0.0;
-       uniformDimensionedVectorField spongeLayerReferenceVelocity
-       (
-           IOobject
-           (
-               "spongeLayerReferenceVelocity",
-               runTime.constant(),
-               mesh,
-               IOobject::NO_READ,
-               IOobject::NO_WRITE
-           ),
-           dimensionedVector("spongeLayerReferenceVelocity",dimensionSet(0, 1, -1, 0, 0, 0, 0),Uref_)
-       );
-       
-       if (spongeLayerType == "Rayleigh")
-       {
-           Info << spongeLayerReferenceVelocity << endl;
-       }
-
-
-
     // PROPERTIES CONCERNING THE WAY IN WHICH PERTURBATION PRESSURE IS DEFINED
 
        // Options for defining the perturbation pressure:

--- a/src/ABLForcing/Make/files
+++ b/src/ABLForcing/Make/files
@@ -1,0 +1,3 @@
+spongeLayer/spongeLayer.C
+
+LIB = $(SOWFA_DIR)/lib/$(WM_OPTIONS)/libSOWFAABLForcing

--- a/src/ABLForcing/Make/options
+++ b/src/ABLForcing/Make/options
@@ -1,0 +1,7 @@
+EXE_INC = \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude
+
+LIB_LIBS = \
+    -lfiniteVolume \
+    -lmeshTools

--- a/src/ABLForcing/include/ABL.H
+++ b/src/ABLForcing/include/ABL.H
@@ -1,0 +1,6 @@
+#ifndef ABL_H
+#define ABL_H
+
+#include "spongeLayer.H"
+
+#endif

--- a/src/ABLForcing/spongeLayer/spongeLayer.C
+++ b/src/ABLForcing/spongeLayer/spongeLayer.C
@@ -1,0 +1,231 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "spongeLayer.H"
+
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(spongeLayer, 0);
+}
+
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+void Foam::spongeLayer::update()
+{
+    // Compute the sponge layer damping force
+    if (type_ == "Rayleigh")
+    {
+        bodyForce_ = viscosity_ * (Uref_ - U_);
+    }
+    else if (type_ == "viscous")
+    {
+        bodyForce_ = fvc::laplacian(viscosity_,U_);
+    }
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::spongeLayer::spongeLayer
+(
+    const word& name,
+    const volVectorField& U
+)
+:
+    // Set name
+    name_(name),
+
+    // Set the pointer to runTime
+    runTime_(U.time()),
+
+    // Set the pointer to the mesh
+    mesh_(U.mesh()),
+
+    // Set the pointer to the velocity field
+    U_(U),
+
+    // Initialize the reference velocity field
+    Uref_
+    (
+        IOobject
+        (
+            name_ & "Uref",
+            runTime_.constant(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        dimensionedVector("Uref_", dimensionSet(0, 1, -1, 0, 0, 0, 0), vector::zero)
+    ),
+
+    // Initialize the viscosity field
+    viscosity_
+    (
+        IOobject
+        (
+            name_ & "viscosity",
+            runTime_.timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh_,
+        dimensionedScalar("viscosity_", dimensionSet(0, 0, -1, 0, 0, 0, 0), 0.0)
+    ),
+
+    // Initialize the body force field
+    bodyForce_
+    (
+        IOobject
+        (
+            name_ & "force",
+            runTime_.timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh_,
+        dimensionedVector("bodyForce",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
+    )
+
+
+{
+    // Define dictionary with input data
+    IOdictionary ABLProperties
+    (
+        IOobject
+        (
+            "ABLProperties",
+            runTime_.time().constant(),
+            runTime_,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE
+        )
+    );
+    
+    const dictionary& spongeDict(ABLProperties.subOrEmptyDict(name_));
+
+    type_ = spongeDict.lookupOrDefault<word>("type","none");
+
+    // Sponge layer start location
+    scalar startLocation = spongeDict.lookupOrDefault<scalar>("startLocation",0.0);
+
+    // Sponge layer width
+    scalar width = spongeDict.lookupOrDefault<scalar>("width",10000.0);
+
+    // Maximum viscosity
+    scalar viscosityMax = spongeDict.lookupOrDefault<scalar>("viscosityMax",0.0); 
+    
+    // Coordinate index
+    label coordIndex = spongeDict.lookupOrDefault<label>("coordIndex",2);
+
+    // Step up or step down
+    word direction = spongeDict.lookupOrDefault<word>("direction","stepUp");
+
+    // Create sponge layer reference velocity
+    scalar Ux = spongeDict.lookupOrDefault<scalar>("Ux",0.0);
+    scalar Uy = spongeDict.lookupOrDefault<scalar>("Uy",0.0);
+    vector Uref;
+    Uref.x() = Ux;
+    Uref.y() = Uy;
+    Uref.z() = 0.0;
+
+    Uref_ = dimensionedVector("Uref", dimensionSet(0, 1, -1, 0, 0, 0, 0), Uref);
+    
+    if (type_ == "Rayleigh" || type_ == "viscous")
+    {
+        Info << "Adding " << name << " layer (" << type_ << " damping) in coordinate direction " << coordIndex;
+        Info << " between " << startLocation << " and " << startLocation+width << " (" << direction;
+        Info << ") with lambdaMax " << viscosityMax << endl;
+    }
+
+    // For a viscous type sponge layer, change the dimensions of the viscosity field from 1/s to m^2/s
+    if (type_ == "viscous")
+    {
+        viscosity_.dimensions().reset(dimensionSet(0, 2, -1, 0, 0, 0, 0));
+    }
+    
+    // Set viscosity to cosine profile between startLocation and startLocation+width,
+    // For step up:   zero below startLocation and one  above startLocation+width
+    // For step down: one  below startLocation and zero above startLocation+width
+    scalar fact = 1.0; //stepUp
+    if (direction == "stepDown")
+    {
+        fact = -1.0;
+    }
+
+    forAll(mesh_.cells(),cellI)
+    {
+        scalar loc = mesh_.C()[cellI][coordIndex];
+        viscosity_[cellI]  = (loc<=startLocation) * (1.0 - fact);
+        viscosity_[cellI] += ((loc>startLocation) && (loc<startLocation+width)) *
+            (
+                1.0 - fact * Foam::cos
+                    (
+                        Foam::constant::mathematical::pi * (loc - startLocation)/width
+                    )
+
+            );
+        viscosity_[cellI] += (loc>=startLocation+width) * (1.0 + fact);
+        viscosity_[cellI] *= 0.5 * viscosityMax;
+
+    }
+
+    forAll(viscosity_.boundaryField(),i)
+    {
+        if ( !mesh_.boundary()[i].coupled() )
+        {
+            forAll(viscosity_.boundaryField()[i],j)
+            {
+                scalar loc = mesh_.boundary()[i].Cf()[j][coordIndex];
+                viscosity_.boundaryField()[i][j]  = (loc<=startLocation) * (1.0 - fact);
+                viscosity_.boundaryField()[i][j] += ((loc>startLocation) && (loc<startLocation+width)) *
+                    (
+                        1.0 - fact * Foam::cos
+                            (
+                                Foam::constant::mathematical::pi * (loc - startLocation)/width
+                            )
+
+                    );
+                viscosity_.boundaryField()[i][j] += (loc>=startLocation+width) * (1.0 + fact);
+                viscosity_.boundaryField()[i][j] *= 0.5 * viscosityMax;
+            }
+        }
+    }
+
+
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::spongeLayer::~spongeLayer()
+{}
+
+
+// ************************************************************************* //

--- a/src/ABLForcing/spongeLayer/spongeLayer.H
+++ b/src/ABLForcing/spongeLayer/spongeLayer.H
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::spongeLayer
+
+Description
+    Sponge layer for damping out vertically propagating gravity waves
+    Possible sponge layer types are "Rayleigh", "viscous" or "none".
+    - The "Rayleigh" type means that the damping term is computed as nu*(u_ref-u)
+      The viscosity coefficient nu has dimensions of 1/s
+    - The "viscous" type means that the damping term is computed as nu * Lapl(u)
+      The viscosity coefficient nu has dimensions of m**2/s
+    - The "none" type means no damping is added
+
+SourceFiles
+    spongeLayer.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef spongeLayer_H
+#define spongeLayer_H
+
+#include "fvCFD.H"
+#include "IOdictionary.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Forward declaration of classes
+
+/*---------------------------------------------------------------------------*\
+                           Class spongeLayer Declaration
+\*---------------------------------------------------------------------------*/
+
+class spongeLayer
+{
+    // Private data
+
+        //- Constants
+            //- Name
+            const word name_;
+
+            //- Runtime pointer
+            const Time& runTime_;
+    
+            //- Mesh pointer
+            const fvMesh& mesh_;
+    
+            //- Velocity field pointer
+            const volVectorField& U_;
+
+        //- Type of sponge layer
+        word type_;
+
+        //- Reference velocity field
+        uniformDimensionedVectorField Uref_;
+
+        //- Viscosity field
+        volScalarField viscosity_;
+
+        //- Body force field of the sponge layer
+        volVectorField bodyForce_;
+
+
+public:
+
+    //- Declare name of the class and its debug switch
+    ClassName("spongeLayer");
+
+
+    // Constructors
+    spongeLayer
+    (
+        const word& name,
+        const volVectorField& U
+    );
+
+
+    // Destructor
+    virtual ~spongeLayer();
+
+
+    // Public Member functions
+
+        //- Update sponge layer force
+        void update();
+
+        //- Return force
+        volVectorField& force()
+        {
+            return bodyForce_;
+        }
+
+
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //


### PR DESCRIPTION
The ad-hoc sponge layer implementation in ABLSolver and ABLTerrainSolver is replaced with a more general implementation of a sponge layer class, thereby avoiding code duplication in the different solvers. Moreover, the general sponge layer class can also be used to specify horizontal sponge layers at the lateral boundaries, although this does require modifying and recompiling the solvers. The input in ABLProperties has been changed so input files of old cases need to be adapted.