### PR TITLE
Add ABLForcing library to SOWFA-6

### DIFF
--- a/Allwclean
+++ b/Allwclean
@@ -31,6 +31,16 @@ rmdepall
 wclean
 cd ../../
 
+cd src/meshTools
+rmdepall
+wclean
+cd ../../
+
+cd src/ABLForcing
+rmdepall
+wclean
+cd ../../
+
 cd src/postProcessing/functionObjects/utilities
 rmdepall
 wclean

--- a/Allwmake
+++ b/Allwmake
@@ -42,6 +42,18 @@ else
     fi	
 fi
 
+# Custom mesh Tools
+cd src/meshTools
+wmake libso
+cd ../../
+
+
+# ABL forcing objects
+cd src/ABLForcing
+wmake libso
+cd ../../
+
+
 # Custom sampling (this includes sampling on an annulus).
 cd src/sampling
 wmake libso

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/Make/options
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/Make/options
@@ -8,9 +8,12 @@ EXE_INC = \
     -I$(LIB_SRC)/thermophysicalModels/radiation/lnInclude \
     -I$(LIB_SRC)/sampling/lnInclude \
     -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/finiteVolume/lnInclude
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(SOWFA_DIR)/src/ABLForcing/lnInclude \
+    -I$(SOWFA_DIR)/src/meshTools/lnInclude
 
 EXE_LIBS = \
+    -L$(SOWFA_DIR)/lib/$(WM_OPTIONS) \
     -lturbulenceModels \
     -lincompressibleTurbulenceModels \
     -lincompressibleTransportModels \

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/TEqn.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/TEqn.H
@@ -9,6 +9,7 @@
         fvm::ddt(T)
       + fvm::div(phi, T)
       - fvm::laplacian(alphaEff, T)
+      - temperatureSourceTerm.force()
      ==
         radiation->ST(rhoCpRef, T)
       + fvOptions(T)

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/UEqn.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/UEqn.H
@@ -7,6 +7,7 @@
         fvm::ddt(U) + fvm::div(phi, U)
       + MRF.DDt(U)
       + turbulence->divDevReff(U)
+      - momentumSourceTerm.force()
      ==
         fvOptions(U)
     );

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/buoyantBoussinesqPimpleFoam.C
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/buoyantBoussinesqPimpleFoam.C
@@ -54,6 +54,7 @@ Description
 #include "radiationModel.H"
 #include "fvOptions.H"
 #include "pimpleControl.H"
+#include "ABL.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -112,6 +113,10 @@ int main(int argc, char *argv[])
                 laminarTransport.correct();
                 turbulence->correct();
             }
+
+            // --- Update the source terms
+            momentumSourceTerm.update();
+            temperatureSourceTerm.update();
         }
 
         runTime.write();

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/createFields.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/createFields.H
@@ -52,6 +52,10 @@ autoPtr<incompressible::turbulenceModel> turbulence
     incompressible::turbulenceModel::New(U, phi, laminarTransport)
 );
 
+// Create external source term objects
+DrivingForce<scalar> temperatureSourceTerm("temperature",T);
+DrivingForce<vector> momentumSourceTerm("momentum",U);
+
 // Kinematic density for buoyancy force
 volScalarField rhok
 (

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/readTransportProperties.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/readTransportProperties.H
@@ -1,0 +1,18 @@
+singlePhaseTransportModel laminarTransport(U, phi);
+
+// Thermal expansion coefficient [1/K]
+dimensionedScalar beta
+(
+    "beta",
+    dimless/dimTemperature,
+    laminarTransport
+);
+
+// Reference temperature [K]
+dimensionedScalar TRef("TRef", dimTemperature, laminarTransport);
+
+// Laminar Prandtl number
+dimensionedScalar Pr("Pr", dimless, laminarTransport);
+
+// Turbulent Prandtl number
+dimensionedScalar Prt("Prt", dimless, laminarTransport);

--- a/src/ABLForcing/CoriolisForce/CoriolisForce.C
+++ b/src/ABLForcing/CoriolisForce/CoriolisForce.C
@@ -1,0 +1,167 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "CoriolisForce.H"
+
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(CoriolisForce, 0);
+}
+
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+void Foam::CoriolisForce::update()
+{
+    // Compute the Coriolis force (neglect the component in the vertical direction).
+    bodyForce_ = -2.0*(Omega_^U_);
+    if (upIndex_ == 0)
+    {
+        forAll(bodyForce_,cellI)
+        {
+            bodyForce_[cellI].x() = 0.0;
+        }
+    }
+    else if (upIndex_ == 1)
+    {
+        forAll(bodyForce_,cellI)
+        {
+            bodyForce_[cellI].y() = 0.0;
+        }
+    }
+    else if (upIndex_ == 2)
+    {
+        forAll(bodyForce_,cellI)
+        {
+            bodyForce_[cellI].z() = 0.0;
+        }
+    }
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::CoriolisForce::CoriolisForce
+(
+    const volVectorField& U,
+    const label upIndex
+)
+:
+    // Set the pointer to runTime
+    runTime_(U.time()),
+
+    // Set the pointer to the mesh
+    mesh_(U.mesh()),
+
+    // Set the pointer to the velocity field
+    U_(U),
+
+    // Set upIndex
+    upIndex_(upIndex),
+
+    // Initialize the reference velocity field
+    Omega_
+    (
+        IOobject
+        (
+            "Omega",
+            runTime_.constant(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        dimensionedVector("Omega_", dimensionSet(0, 0, -1, 0, 0, 0, 0), vector::zero)
+    ),
+
+    // Initialize the body force field
+    bodyForce_
+    (
+        IOobject
+        (
+            "Coriolisforce",
+            runTime_.timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh_,
+        dimensionedVector("bodyForce",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
+    )
+
+
+{
+    // Define dictionary with input data
+    IOdictionary ABLProperties
+    (
+        IOobject
+        (
+            "ABLProperties",
+            runTime_.time().constant(),
+            runTime_,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE
+        )
+    );
+
+    // Planetary rotation period (hours)
+    scalar planetaryRotationPeriod(readScalar(ABLProperties.lookup("planetaryRotationPeriod")));
+
+    // Latitude on the planetary body (degrees)
+    scalar latitude(readScalar(ABLProperties.lookup("latitude")));
+    
+    // Compute the planetar rotation vector
+    vector Omega;
+    Omega.x() = 0.0;
+    Omega.y() =
+        (
+            ( 2.0 * Foam::constant::mathematical::pi ) /
+            ( max(1.0E-5,planetaryRotationPeriod)*3600.0)
+        ) *
+        Foam::cos( latitude*Foam::constant::mathematical::pi/180.0 );
+    Omega.z() =
+        (
+            ( 2.0 * Foam::constant::mathematical::pi ) /
+            ( max(1.0E-5,planetaryRotationPeriod)*3600.0)
+        ) *
+        Foam::sin( latitude*Foam::constant::mathematical::pi/180.0 );
+
+    Omega_ = dimensionedVector("Omega", dimensionSet(0, 0, -1, 0, 0, 0, 0), Omega);
+
+    Info << "Creating Coriolis force object" << endl;
+    Info << Omega_ << endl;
+
+
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::CoriolisForce::~CoriolisForce()
+{}
+
+
+// ************************************************************************* //

--- a/src/ABLForcing/CoriolisForce/CoriolisForce.H
+++ b/src/ABLForcing/CoriolisForce/CoriolisForce.H
@@ -1,0 +1,116 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::CoriolisForce
+
+Description
+    Coriolis force object
+
+SourceFiles
+    CoriolisForce.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef CoriolisForce_H
+#define CoriolisForce_H
+
+#include "fvCFD.H"
+#include "IOdictionary.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Forward declaration of classes
+
+/*---------------------------------------------------------------------------*\
+                           Class CoriolisForce Declaration
+\*---------------------------------------------------------------------------*/
+
+class CoriolisForce
+{
+    // Private data
+
+        //- Constants
+            //- Runtime pointer
+            const Time& runTime_;;
+    
+            //- Mesh pointer
+            const fvMesh& mesh_;
+    
+            //- Velocity field pointer
+            const volVectorField& U_;
+
+            //- upIndex
+            const label upIndex_;
+
+        //- Planetary rotation vector field
+        uniformDimensionedVectorField Omega_;
+
+        //- Coriolis force
+        volVectorField bodyForce_;
+
+
+public:
+
+    //- Declare name of the class and its debug switch
+    ClassName("CoriolisForce");
+
+
+    // Constructors
+    CoriolisForce
+    (
+        const volVectorField& U,
+        const label upIndex
+    );
+
+
+    // Destructor
+    virtual ~CoriolisForce();
+
+
+    // Public Member functions
+
+        //- Update Coriolis force
+        void update();
+
+        //- Return force
+        volVectorField& force()
+        {
+            return bodyForce_;
+        }
+
+
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/ABLForcing/Make/files
+++ b/src/ABLForcing/Make/files
@@ -1,0 +1,6 @@
+spongeLayer/spongeLayer.C
+CoriolisForce/CoriolisForce.C
+buoyancyModel/buoyancyModel.C
+drivingForce/drivingForce.C
+
+LIB = $(SOWFA_DIR)/lib/$(WM_OPTIONS)/libSOWFAABLForcing

--- a/src/ABLForcing/Make/options
+++ b/src/ABLForcing/Make/options
@@ -1,0 +1,12 @@
+EXE_INC = \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(SOWFA_DIR)/src/meshTools/lnInclude \
+    -Iinterpolate2D \
+    -IwindRoseToCartesian
+
+LIB_LIBS = \
+    -L$(SOWFA_DIR)/lib/$(WM_OPTIONS) \
+    -lfiniteVolume \
+    -lmeshTools \
+    -lSOWFAmeshTools

--- a/src/ABLForcing/buoyancyModel/buoyancyModel.C
+++ b/src/ABLForcing/buoyancyModel/buoyancyModel.C
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "buoyancyModel.H"
+
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(buoyancyModel, 0);
+}
+
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+void Foam::buoyancyModel::updateBuoyancyTerm()
+{
+    // Compute the buoyancy term, depending on the definition of
+    // the background pressure
+
+    if (backgroundPressureType_ == "noSplit")
+    {
+        buoyancyTerm_ = ((g_ & mesh_.Sf())/mesh_.magSf()) * fvc::interpolate(rhok_);
+    }
+    else if (backgroundPressureType_ == "rho0Split")
+    {
+        buoyancyTerm_ = ((g_ & mesh_.Sf())/mesh_.magSf()) * fvc::interpolate(rhok_ - 1.0);
+    }
+    else if (backgroundPressureType_ == "rhokSplit")
+    {
+        buoyancyTerm_ = -ghf_*fvc::snGrad(rhok_);
+    }
+}
+
+void Foam::buoyancyModel::updateBackgroundPressure()
+{
+    if (backgroundPressureType_ == "noSplit")
+    {
+        pBackground_ = 0.0;
+    }
+    else if (backgroundPressureType_ == "rho0Split")
+    {
+        pBackground_ = gh_;
+    }
+    else if (backgroundPressureType_ == "rhokSplit")
+    {
+        pBackground_ = rhok_ * gh_;
+    }
+}
+
+void Foam::buoyancyModel::updateDensityField()
+{
+    rhok_ = 1.0 - ( (T_ - TRef_)/TRef_ );
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::buoyancyModel::buoyancyModel
+(
+    const volScalarField& T,
+    const dimensionedScalar TRef,
+    const dimensionedVector hRef
+)
+:
+    // Set the pointer to runTime
+    runTime_(T.time()),
+
+    // Set the pointer to the mesh
+    mesh_(T.mesh()),
+
+    // Set the pointer to the temperature field
+    T_(T),
+
+    // Set the reference temperature
+    TRef_(TRef),
+
+    // Initialize the gravitational acceleration field
+    g_(T.db().lookupObject<uniformDimensionedVectorField>("g")),
+
+    // Initialize the Boussinesq density field
+    rhok_
+    (
+        IOobject
+        (
+            "rhok",
+            runTime_.timeName(),
+            mesh_
+        ),
+        1.0 - ( (T - TRef)/TRef )
+    ),
+
+    // Initialize the gravity potential field
+    gh_("gh", g_ & (mesh_.C() - hRef)),
+    ghf_("ghf", g_ & (mesh_.Cf() - hRef)),
+
+    // Initialize background pressure
+    pBackground_("pBackground", rhok_*gh_),
+
+    // Initialize the buoyancy term
+    buoyancyTerm_("buoyancyTerm", -ghf_ * fvc::snGrad(rhok_))
+
+
+{
+    // Define dictionary with input data
+    IOdictionary ABLProperties
+    (
+        IOobject
+        (
+            "ABLProperties",
+            runTime_.time().constant(),
+            runTime_,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE
+        )
+    );
+
+    // PROPERTIES CONCERNING THE WAY IN WHICH THE BACKGROUND PRESSURE IS DEFINED
+
+    // Options for defining the background pressure:
+    // - noSplit:   do not split out hydrostatic part; pressure is then perturbation pressure.
+    // - rho0Split: split out the hydrostatic part; define hydrostatic as rho_0 * g * z.
+    // - rhokSplit: split out the hydrostatic part; define hydrostatic as rho_k * g * z.
+    backgroundPressureType_ = ABLProperties.lookupOrDefault<word>("perturbationPressureType","rhokSplit");
+    word backgroundOutput;
+    if (backgroundPressureType_ == "noSplit")
+    {
+        backgroundOutput = "nothing";
+    }
+    else if (backgroundPressureType_ == "rho0Split")
+    {
+        backgroundOutput = "rho_0 * g * z";
+    }
+    else if (backgroundPressureType_ == "rhokSplit")
+    {
+        backgroundOutput = "rho_k * g * z";
+    }
+    Info << "Defining background hydrostatic pressure to be " << backgroundOutput << endl;
+
+
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::buoyancyModel::~buoyancyModel()
+{}
+
+
+// ************************************************************************* //

--- a/src/ABLForcing/buoyancyModel/buoyancyModel.H
+++ b/src/ABLForcing/buoyancyModel/buoyancyModel.H
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::buoyancyModel
+
+Description
+    Buoyancy model
+    Currently only Boussinesq
+
+SourceFiles
+    buoyancyModel.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef buoyancyModel_H
+#define buoyancyModel_H
+
+#include "fvCFD.H"
+#include "IOdictionary.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Forward declaration of classes
+
+/*---------------------------------------------------------------------------*\
+                           Class buoyancyModel Declaration
+\*---------------------------------------------------------------------------*/
+
+class buoyancyModel
+{
+    // Private data
+
+        //- Constants
+            //- Runtime pointer
+            const Time& runTime_;;
+    
+            //- Mesh pointer
+            const fvMesh& mesh_;
+    
+            //- Temperature field pointer
+            const volScalarField& T_;
+
+            //- Reference temperature [K]
+            const dimensionedScalar TRef_;
+
+            //- Gravitational acceleration field
+            const uniformDimensionedVectorField& g_;
+
+        //- Boussinesq density field
+        volScalarField rhok_;
+
+        //- Gravioty potential field
+        volScalarField gh_;
+        surfaceScalarField ghf_;
+
+        //- Background pressure field
+        volScalarField pBackground_;
+
+        //- Buoyancy term
+        surfaceScalarField buoyancyTerm_;
+
+        //- Definition of the background hydrostatic pressure
+        word backgroundPressureType_;
+
+
+public:
+
+    //- Declare name of the class and its debug switch
+    ClassName("buoyancyModel");
+
+
+    // Constructors
+    buoyancyModel
+    (
+        const volScalarField& T,
+        const dimensionedScalar TRef,
+        const dimensionedVector hRef
+    );
+
+
+    // Destructor
+    virtual ~buoyancyModel();
+
+
+    // Public Member functions
+
+        //- Update buoyancy term
+        void updateBuoyancyTerm();
+
+        //- Update background pressure
+        void updateBackgroundPressure();
+
+        //- Update density field 
+        void updateDensityField();
+
+        //- Return bakcground pressure
+        volScalarField& backgroundPressure()
+        {
+            return pBackground_;
+        }
+
+        //- Return buoyancy term
+        surfaceScalarField& buoyancyTerm()
+        {
+            return buoyancyTerm_;
+        }
+
+
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/ABLForcing/drivingForce/DrivingForce.C
+++ b/src/ABLForcing/drivingForce/DrivingForce.C
@@ -1,0 +1,640 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "DrivingForce.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+template<class Type>
+void Foam::DrivingForce<Type>::updateGivenTimeDepSource_()
+{
+    // Interpolate specified source to current time
+    Type source = interpolate2D(runTime_.value(),
+                                sourceHeightsSpecified_[0],
+                                sourceTimesSpecified_,
+                                sourceHeightsSpecified_,
+                                sourceSpecified_);
+
+
+    // Apply in all grid cells
+    forAll(bodyForce_,cellI)
+    {
+        bodyForce_[cellI] = source;
+    }
+
+
+    // Write the source information.
+    writeSourceHistory_(source);
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::updateGivenTimeHeightDepSource_()
+{
+    // Interpolate specified source values in time and height
+    List<Type> source = interpolate2D(runTime_.value(),
+                                zPlanes_.planeLocationValues(),
+                                sourceTimesSpecified_,
+                                sourceHeightsSpecified_,
+                                sourceSpecified_);
+
+
+    // Now go by cell levels and apply the source term
+    forAllPlanes(zPlanes_,planeI)
+    {
+        for (label i = 0; i < zPlanes_.numCellPerPlane()[planeI]; i++)
+        {
+            label cellI = zPlanes_.planesCellList()[planeI][i];
+            bodyForce_[cellI] = source[planeI];
+        }
+    }
+
+
+    // Write the column of source information.
+    writeSourceHistory_(source);
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::updateComputedTimeDepSource_()
+{
+    // Get the current time step size.
+    scalar dt = runTime_.deltaT().value();
+
+    // Interpolate the desired field to current time
+    Type desiredField = interpolate2D(runTime_.value(),
+                                sourceHeightsSpecified_[0],
+                                sourceTimesSpecified_,
+                                sourceHeightsSpecified_,
+                                sourceSpecified_);
+   
+    // Convert from speedAndDirection to component if necessary
+    Type fldMeanDesired(zeroTensor_());
+    if (velocityInputType_ == "component")
+    {
+        fldMeanDesired = desiredField;
+    }
+    else if (velocityInputType_ == "speedAndDirection")
+    {
+        fldMeanDesired = speedDirToComp_(desiredField);
+    }
+
+
+    // Calculate the average field at the closest level to specified
+    Type fldMean1 = zPlanes_.average<Type>(field_,hLevels1I);
+
+    // Calculate the average field at the next closest level to specified
+    Type fldMean2 = zPlanes_.average<Type>(field_,hLevels2I);
+
+    // Linearly interpolate to get the average field value at the desired height
+    Type fldMean = fldMean1 + (((fldMean2 - fldMean1)/(hLevels2 - hLevels1)) * (sourceHeightsSpecified_[0] - hLevels1));
+   
+
+    // Compute the source term
+    Type ds = (fldMeanDesired - fldMean) / dt;
+
+    // Apply the relaxation
+    ds *= alpha_;
+
+    // Update the source term
+    forAll(bodyForce_,cellI)
+    {
+        bodyForce_[cellI] = ds;
+    }
+
+    bodyForce_.correctBoundaryConditions();
+    
+    // Write the source information
+    writeSourceHistory_(ds);
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::updateComputedTimeHeightDepSource_()
+{
+    // Interpolate specified source values in time and height
+    List<Type> fldMeanDesired = interpolate2D(runTime_.value(),
+                                zPlanes_.planeLocationValues(),
+                                sourceTimesSpecified_,
+                                sourceHeightsSpecified_,
+                                sourceSpecified_);
+
+
+    // Compute the planar-averaged actual field at each cell level
+    List<Type> fldMean = zPlanes_.average<Type>(field_);
+
+    // Compute the error at each cell level
+    List<Type> fldError = fldMeanDesired - fldMean;
+
+    // Compute the controller action
+    List<Type> source = updateController_(fldError);
+
+    // Now go by cell levels and apply the source term
+    forAllPlanes(zPlanes_,planeI)
+    {
+        for (label i = 0; i < zPlanes_.numCellPerPlane()[planeI]; i++)
+        {
+            label cellI = zPlanes_.planesCellList()[planeI][i];
+            bodyForce_[cellI] = source[planeI];
+        }
+    }
+    bodyForce_.correctBoundaryConditions();
+
+
+    // Write the column of source information.
+    writeSourceHistory_(source);
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::writeSourceHistory_
+(
+    Type& source
+)
+{
+    // Write the source information.
+    if (Pstream::master())
+    {
+        if (statisticsOn_)
+        {
+            if (runTime_.timeIndex() % statisticsFreq_ == 0)
+            {
+                sourceHistoryFile_() << runTime_.timeName() << " " << runTime_.deltaT().value() << " " << source << endl;
+            }
+        }
+    }
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::writeSourceHistory_
+(
+    List<Type>& source
+)
+{
+    // Write the column of source information.
+    if (Pstream::master())
+    {
+        if (statisticsOn_)
+        {
+            if (runTime_.timeIndex() % statisticsFreq_ == 0)
+            {
+                sourceHistoryFile_() << runTime_.timeName() << " " << runTime_.deltaT().value();
+
+                forAllPlanes(zPlanes_,planeI)
+                {
+                   sourceHistoryFile_() << " " << source[planeI];
+                }
+
+                sourceHistoryFile_() << endl;
+            }
+        }
+    }
+}
+
+
+// In general, input type speedAndDirection is not supported
+template<class Type>
+Type Foam::DrivingForce<Type>::speedDirToComp_
+(
+    Type desiredField
+)
+{
+    FatalErrorIn
+    (
+        "Input type 'speedAndDirection' only supported for driving force of type vector"
+    ) << abort(FatalError);
+
+    return zeroTensor_();
+}
+
+
+// Specialization for Type vector where input type speedAndDirection is supported
+namespace Foam
+{
+    template<>
+    vector Foam::DrivingForce<vector>::speedDirToComp_
+    (
+        vector desiredField
+    )
+    {
+        vector fldMeanDesired = windRoseToCartesian(desiredField.x(),desiredField.y());
+        fldMeanDesired.z() = desiredField.z();
+        return fldMeanDesired;
+    }
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::readInputData_()
+{
+    // Define dictionary with input data
+    IOdictionary ABLProperties
+    (
+        IOobject
+        (
+            "ABLProperties",
+            runTime_.time().constant(),
+            runTime_,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE
+        )
+    );
+
+    // PROPERTIES CONCERNING THE SOURCE TERMS.
+
+    // Specify the type of source to use.  The
+    // possible types are "given" and "computed".  
+    // - The "given" type means that the source values are directly given
+    //   and the momentum and temperature fields will react accordingly.  
+    // - The "computed" type means that the mean velocity and temperature
+    //   are given and the source terms that maintain them are computed. 
+    word sourceType(ABLProperties.lookup(name_ & "SourceType"));
+    sourceType_ = sourceType;
+    
+
+    // If giving the velocity and computing the sources, specify how the velocity
+    // is given.  "component" means you enter the x, y, anc z components.
+    // "speedAndDirection" means that you enter the horizontal wind speed, horizontal
+    // direction, and vertical component.
+    if (name_ == "momentum")
+    {
+        word velocityInputType(ABLProperties.lookup("velocityInputType"));
+        velocityInputType_ = velocityInputType;
+    }
+    else
+    {
+        velocityInputType_ = "component";
+    }
+    
+
+    // Read in the heights at which the sources are given.
+    List<scalar> sourceHeightsSpecified = ABLProperties.lookup("sourceHeights" & name_);
+    sourceHeightsSpecified_ = sourceHeightsSpecified;
+    label nSourceHeights = sourceHeightsSpecified_.size();
+
+
+    // Read in the source table(s) vs. time and height
+    readSourceTables_(ABLProperties,nSourceHeights);
+
+
+    // Read in controller properties.
+    scalar alpha(ABLProperties.lookupOrDefault<scalar>("alpha" & name_,1.0));
+    alpha_ = alpha;
+    
+    // Initialize controller
+    initializeController_(nSourceHeights);
+
+    // If the desired mean wind or temperature is given at only one height, then revert to
+    // the old way of specifying the source term.  Find the two grid levels that bracket
+    // the given level and interpolate in between them to compute the source term.  So,
+    // here, find those two levels.
+    if ((sourceType_ == "computed") && (nSourceHeights == 1))
+    {
+        findSingleForcingHeight_();
+    }
+
+
+    // PROPERTIES CONCERNING GATHERING STATISTICS
+
+    // Gather/write statistics?
+    bool statisticsOn(ABLProperties.lookupOrDefault<bool>("statisticsOn",false));
+    statisticsOn_ = statisticsOn;
+
+    // Statistics gathering/writing frequency?
+    int statisticsFreq(int(readScalar(ABLProperties.lookup("statisticsFrequency"))));
+    statisticsFreq_ = statisticsFreq;
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::readSourceTables_
+(
+    IOdictionary& ABLProperties,
+    label& nSourceHeights
+)
+{
+    List<List<List<scalar> > > sourceTables;
+
+    for(int i = 0; i < Type::nComponents; i++)
+    {
+        word sourceTableName = ("sourceTable" & name_) & Type::componentNames[i];
+
+        Info << "Reading " << sourceTableName << endl;
+        List<List<scalar> > sourceTable( ABLProperties.lookup(sourceTableName) );
+
+        checkSourceTableSize_( sourceTableName, sourceTable, nSourceHeights);
+
+        sourceTables.append(sourceTable);
+    }
+
+    // Assuming that the specified times are the same for all components
+    label nSourceTimes = sourceTables[0].size();
+
+    for(int i = 0; i < nSourceTimes; i++)
+    {
+        sourceTimesSpecified_.append(sourceTables[0][i][0]);
+        sourceSpecified_.append(List<Type>(nSourceHeights,Type::zero));
+
+        for(int j = 0; j < nSourceHeights; j++)
+        {
+            Type s(Type::zero);
+
+            for(int k = 0; k < Type::nComponents; k++)
+            {
+                s[k] = sourceTables[k][i][j+1];
+            }
+
+            sourceSpecified_[i][j] = s;
+        }
+    }
+}
+
+
+// Specialization for scalar
+// Type scalar does not have nComponent nor componentNames
+namespace Foam
+{
+    template<>
+    void DrivingForce<scalar>::readSourceTables_
+    (
+        IOdictionary& ABLProperties,
+        label& nSourceHeights
+    )
+    {
+        word sourceTableName = "sourceTable" & name_;
+
+        Info << "Reading " << sourceTableName << endl;
+        List<List<scalar> > sourceTable( ABLProperties.lookup(sourceTableName) );
+
+        checkSourceTableSize_( sourceTableName, sourceTable, nSourceHeights);
+    
+        // Assuming that the specified times are the same for all components
+        label nSourceTimes = sourceTable.size();
+    
+        for(int i = 0; i < nSourceTimes; i++)
+        {
+            sourceTimesSpecified_.append(sourceTable[i][0]);
+            sourceSpecified_.append(List<scalar>(nSourceHeights,0.0));
+
+            for(int j = 0; j < nSourceHeights; j++)
+            {
+                sourceSpecified_[i][j] = sourceTable[i][j+1];
+            }
+        }
+    }
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::checkSourceTableSize_
+(
+    word& sourceTableName,
+    List<List<scalar> >& sourceTable,
+    label& nSourceHeights
+)
+{
+    forAll(sourceTable,i)
+    {
+        if (sourceTable[i].size()-1 != nSourceHeights)
+        {
+            FatalErrorIn
+            (
+                "Number of " + sourceTableName + " heights does not match number of heights specified"
+            )   << abort(FatalError);
+        }
+    }
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::findSingleForcingHeight_()
+{
+    scalar hLevels1Diff = 0.0;
+    scalar hLevels2Diff = 0.0;
+
+    // Find the grid levels closest to the specified height
+    List<scalar> hLevelsDiff(zPlanes_.numberOfPlanes());
+    forAllPlanes(zPlanes_,planeI)
+    {
+        hLevelsDiff[planeI] = zPlanes_.planeLocationValues()[planeI] - sourceHeightsSpecified_[0];
+    }
+
+    // Find the two levels closest to the specified height
+    // Find the closest level
+    forAllPlanes(zPlanes_,planeI)
+    {
+        if (planeI == 0)
+        {
+            hLevels1I = planeI;
+            hLevels1Diff = hLevelsDiff[planeI];
+            hLevels1 = zPlanes_.planeLocationValues()[planeI];
+        }
+        else
+        {
+            if ( mag(hLevelsDiff[planeI]) < mag(hLevels1Diff) )
+            {
+                hLevels1I = planeI;
+                hLevels1Diff = hLevelsDiff[planeI];
+                hLevels1 = zPlanes_.planeLocationValues()[planeI];
+            }
+        }
+    }
+
+    // Find the next closest level
+    int j = 0;
+    forAllPlanes(zPlanes_,planeI)
+    {
+        if (planeI != hLevels1I)
+        {
+            if (j == 0)
+            {
+                hLevels2I = planeI;
+                hLevels2Diff = hLevelsDiff[planeI];
+                hLevels2 = zPlanes_.planeLocationValues()[planeI];
+            }
+            else
+            {
+                if ( mag(hLevelsDiff[planeI]) < mag(hLevels2Diff) )
+                {
+                    hLevels2I = planeI;
+                    hLevels2Diff = hLevelsDiff[planeI];
+                    hLevels2 = zPlanes_.planeLocationValues()[planeI];
+                }
+            }
+            j++;
+        }
+    }
+}
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::openFiles_()
+{
+    fileName outputPath(fileName::null);
+
+    // Specify output path
+    if (Pstream::parRun())
+    {
+        outputPath = mesh_.time().path()/".."/"postProcessing"/"sourceHistory"/mesh_.time().timeName();
+    }
+    else
+    {
+        outputPath = mesh_.time().path()/"postProcessing"/"sourceHistory"/mesh_.time().timeName();
+    }
+
+    if (Pstream::master)
+    {
+        // Create directory if it does not exist
+        mkDir(outputPath);
+
+        word sourceFileName = ("Source" & name_) & "History";
+        sourceHistoryFile_.reset(new OFstream(outputPath/sourceFileName));
+        
+        if (sourceHeightsSpecified_.size() > 1)
+        {
+            sourceHistoryFile_() << "Heights (m) ";
+            forAllPlanes(zPlanes_,planeI)
+            {
+                sourceHistoryFile_() << zPlanes_.planeLocationValues()[planeI] << " ";
+            }
+            sourceHistoryFile_() << endl;
+        }
+
+        sourceHistoryFile_() << "Time(s)" << " " << "dt (s)" << " " << "source term " << bodyForce_.dimensions() << endl;
+    }
+}
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+template<class Type>
+Foam::DrivingForce<Type>::DrivingForce
+(
+    const word& name,
+    const GeometricField<Type, fvPatchField, volMesh>& field
+)
+:
+    // Set name
+    name_(name),
+
+    // Set the pointer to runTime
+    runTime_(field.time()),
+
+    // Set the pointer to the mesh
+    mesh_(field.mesh()),
+
+    // Set the pointer to the velocity field
+    field_(field),
+
+    // Compute vertical levels
+    zPlanes_(mesh_),
+
+    // Initialize the body force field
+    bodyForce_
+    (
+        IOobject
+        (
+            "source" & name_,
+            runTime_.timeName(),
+            mesh_,
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        mesh_,
+        dimensioned<Type>("source" & name_,dimensionSet(field_.dimensions()/dimTime),zeroTensor_())
+    ),
+
+    // Initialize output file pointer
+    sourceHistoryFile_(NULL),
+
+    // Initialize height levels and indices for forcing at one height
+    hLevels1I(0.0),
+    hLevels2I(0.0),
+    hLevels1(0.0),
+    hLevels2(0.0)
+{
+    Info << "Creating driving force object with for " << name_ << endl;
+
+    readInputData_();
+    openFiles_();
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+template<class Type>
+Foam::DrivingForce<Type>::~DrivingForce()
+{}
+
+
+// * * * * * * * * * * * * * Public Member Functions  * * * * * * * * * * * //
+
+template<class Type>
+void Foam::DrivingForce<Type>::update()
+{
+    // Source terms are applied directly as given
+    if (sourceType_ == "given")
+    {
+        // Source is only given at one height. In this case,
+        // assume the source is set uniformly throughout the domain to the
+        // given value as a function of time only.
+        if (sourceHeightsSpecified_.size() == 1)
+        {
+            updateGivenTimeDepSource_();
+        }
+
+        // Otherwise, set the source as a function of height and time
+        else
+        {
+            updateGivenTimeHeightDepSource_();
+        }
+    }
+
+    // Source terms have to be computed
+    else if (sourceType_ == "computed")
+    {
+        // Field is only specified at one height. In this case,
+        // a source term will be computed and applied uniformly in all three
+        // dimensions, the same as in the original ABLSolver.
+        if (sourceHeightsSpecified_.size() == 1)
+        {
+            updateComputedTimeDepSource_();
+        }
+
+        // Otherwise, set the source as a function of height and time
+        else
+        {
+            updateComputedTimeHeightDepSource_();
+        }
+    }
+}
+
+
+
+// ************************************************************************* //

--- a/src/ABLForcing/drivingForce/DrivingForce.H
+++ b/src/ABLForcing/drivingForce/DrivingForce.H
@@ -1,0 +1,242 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::DrivingForce<Type>
+
+Description
+    Driving force
+
+SourceFiles
+    DrivingForce.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef DrivingForce_H
+#define DrivingForce_H
+
+#include "fvCFD.H"
+#include "IOdictionary.H"
+#include "meshPlanes.H"
+#include "interpolate2D.H"
+#include "windRoseToCartesian.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Forward declaration of classes
+
+/*---------------------------------------------------------------------------*\
+                           Class drivingForce Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class Type>
+class DrivingForce
+{
+    // Private data
+
+
+        typedef GeometricField<Type, fvPatchField, volMesh> volFieldType;
+
+
+        //- Constants
+        
+            //- Name
+            const word name_;
+
+            //- Runtime pointer
+            const Time& runTime_;
+    
+            //- Mesh pointer
+            const fvMesh& mesh_;
+    
+            //- Field pointer
+            const volFieldType& field_;
+
+
+        //- Vertical mesh planes
+        meshPlanes zPlanes_;
+
+        //- Driving force field
+        volFieldType bodyForce_;
+
+        //- Output file pointer
+        autoPtr<OFstream> sourceHistoryFile_;
+
+        //- Type of source
+        word sourceType_;
+
+        //- Velocity input type (only used when name_ == "momentum")
+        word velocityInputType_;
+
+        //- Heights at which the sources are given
+        List<scalar> sourceHeightsSpecified_;
+
+        //- Times at which the sources are given
+        List<scalar> sourceTimesSpecified_;
+
+        //- Source interpolation table
+        List<List<Type> > sourceSpecified_;
+
+        //- Height level indices for forcing at one height
+        label hLevels1I;
+        label hLevels2I;
+
+        //- Height levels for forcing at one height
+        scalar hLevels1;
+        scalar hLevels2;
+
+        //- Relaxation coefficient
+        scalar alpha_;
+
+        //- Gather/write statistics?
+        bool statisticsOn_;
+
+        //- Statistics gathering/writing frequency?
+        int statisticsFreq_;
+
+
+    // Private Member Functions
+
+
+        //- Return zero object of type for initialisation
+        Type zeroTensor_()
+        {
+            return Type::zero;
+        }
+
+
+        //- Read input data from ABLProperties dictionary
+        void readInputData_();
+
+
+        //- Read source tables (componentwise)
+        void readSourceTables_
+        (
+            IOdictionary& ABLProperties,
+            label& nSourceHeights
+        );
+            
+
+        //- Check size of source table
+        void checkSourceTableSize_
+        (
+            word& sourceTableName,
+            List<List<scalar> >& sourceTable,
+            label& nSourceHeights
+        );
+
+        //- Find grid levels closest to specified height
+        void findSingleForcingHeight_();
+
+        //- Open file streams
+        void openFiles_();
+
+        //- Update given time-dependent source term
+        void updateGivenTimeDepSource_();
+
+        //- Update given time-height-dependent source term
+        void updateGivenTimeHeightDepSource_();
+
+        //- Update computed time-dependent source term
+        void updateComputedTimeDepSource_();
+
+        //- Update computed time-height-dependent source term
+        void updateComputedTimeHeightDepSource_();
+
+        //- Initialize controller
+        void initializeController_(label nSourceHeights);
+
+        //- Update controller
+        List<Type> updateController_(List<Type>& error);
+
+        //- Write source history to file (single value or column of values)
+        void writeSourceHistory_(Type& source);
+        void writeSourceHistory_(List<Type>& source);
+
+        //- Convert speedAndDirection input to components (only for Type vector)
+        Type speedDirToComp_
+        (
+            Type desiredField
+        );
+
+public:
+
+    //- Runtime type information
+    ClassName("DrivingForce");
+
+
+    // Constructors
+    DrivingForce
+    (
+        const word& name,
+        const volFieldType& field
+    );
+
+
+    // Destructor
+    virtual ~DrivingForce();
+
+
+    // Public Member functions
+
+        //- Update source term
+        void update();
+
+        //- Return bodyforce
+        volFieldType& force()
+        {
+            return bodyForce_;
+        }
+
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+// specialization for scalar driving force
+template<>
+scalar DrivingForce<scalar>::zeroTensor_()
+{
+    return 0.0;
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+#   include "DrivingForce.C"
+#   include "DrivingForceController.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/ABLForcing/drivingForce/DrivingForceController.C
+++ b/src/ABLForcing/drivingForce/DrivingForceController.C
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "DrivingForce.H"
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+
+template<class Type>
+void Foam::DrivingForce<Type>::initializeController_
+(
+    label nSourceHeights
+)
+{
+    //Nothing to be initialized for now
+}
+
+
+template<class Type>
+List<Type> Foam::DrivingForce<Type>::updateController_
+(
+    List<Type>& error
+)
+{
+    // Get the current time step size.
+    scalar dt = runTime_.deltaT().value();
+    
+    // Compute controller action
+    List<Type> source = alpha_/dt * error;
+
+    return source;
+}
+
+
+// ************************************************************************* //

--- a/src/ABLForcing/drivingForce/drivingForce.C
+++ b/src/ABLForcing/drivingForce/drivingForce.C
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "DrivingForce.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+//defineTemplateTypeNameAndDebugWithName
+//(
+//    Foam::DrivingForce<Foam::scalar>,
+//    "scalarDrivingForce",
+//    0
+//);
+
+namespace Foam
+{
+    template class DrivingForce<scalar>;
+    template class DrivingForce<vector>;
+}
+
+// ************************************************************************* //

--- a/src/ABLForcing/include/ABL.H
+++ b/src/ABLForcing/include/ABL.H
@@ -1,0 +1,9 @@
+#ifndef ABL_H
+#define ABL_H
+
+#include "spongeLayer.H"
+#include "CoriolisForce.H"
+#include "buoyancyModel.H"
+#include "DrivingForce.H"
+
+#endif

--- a/src/ABLForcing/interpolate2D/interpolate2D.C
+++ b/src/ABLForcing/interpolate2D/interpolate2D.C
@@ -1,0 +1,256 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "interpolate2D.H"
+#include "primitiveFields.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+template<class Type>
+List<List<Type> > interpolate2D
+(
+    const List<scalar>& xi,
+    const List<scalar>& yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+)
+{
+    // Get size of interpolation point lists.
+    label nxi = xi.size();
+    label nyi = yi.size();
+
+    // Interpolate element by element.
+    List<List<Type> > fi(nxi,List<Type>(nyi));
+    forAll(xi, i)
+    {
+        forAll(yi, j)
+        {
+            fi[i][j] = interpolate2D(xi[i],yi[j],x,y,f);
+        }
+    }
+    return fi;
+}
+
+
+template<class Type>
+List<Type> interpolate2D
+(
+    const scalar& xi,
+    const List<scalar>& yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+)
+{
+    // Get size of interpolation point lists.
+    label nyi = yi.size();
+
+    // Interpolate element by element.
+    List<Type> fi(nyi);
+    forAll(yi, j)
+    {
+        fi[j] = interpolate2D(xi,yi[j],x,y,f);
+    }
+    return fi;
+}
+
+
+template<class Type>
+List<Type> interpolate2D
+(
+    const List<scalar>& xi,
+    const scalar& yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+)
+{
+    // Get size of interpolation point lists.
+    label nxi = xi.size();
+
+    // Interpolate element by element.
+    List<Type> fi(nxi);
+    forAll(xi, i)
+    {
+        fi[i] = interpolate2D(xi[i],yi,x,y,f);
+    }
+    return fi;
+}
+
+
+template<class Type>
+Type interpolate2D
+(
+    const scalar xi,
+    const scalar yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+)
+{
+    // Get interpolation data size.
+    label nx = x.size();
+    label ny = y.size();
+    label nxf = f.size();
+    label nyf = f[0].size();
+
+
+    // Check to make sure data sizes all match up.  Does the size of x
+    // match the x-index size of f, and same with y.  Give error message
+    // and exit if not.
+    if ((nx != nxf) || (ny != nyf))
+    {
+        FatalErrorIn
+        (
+            "interpolate2d"
+        ) << "Sizes of input x and y vectors do not match size of f array:" << endl <<
+             "x size: " << nx << endl <<
+             "y size: " << ny << endl <<
+             "f(x,y) size: " << nxf << ", " << nyf <<
+             abort(FatalError);
+    }
+
+
+    // Find bounding indices in x.
+    label xLow = 0;
+    while ((xLow < nx) && (x[xLow] < xi))
+    {
+        xLow++;
+    }
+    xLow--;
+    xLow = max(xLow,0);
+
+    label xHigh = nx - 1;
+    while ((xHigh >= 0) && (x[xHigh] >= xi))
+    {
+        xHigh--;
+    }
+    xHigh++;
+    xHigh = min(xHigh,nx - 1);
+
+
+    // Find bounding indices in y.
+    label yLow = 0;
+    while ((yLow < ny) && (y[yLow] < yi))
+    {
+        yLow++;
+    }
+    yLow--;
+    yLow = max(yLow,0);
+
+    label yHigh = ny - 1;
+    while ((yHigh >= 0) && (y[yHigh] >= yi))
+    {
+        yHigh--;
+    }
+    yHigh++;
+    yHigh = min(yHigh,ny - 1);
+
+
+    // If, the data point lies outside the x or y given data ranges
+    // set up the high and low indices so that linear extrapolation
+    // will be done.
+    if (xHigh == xLow)
+    {
+        if (xHigh == 0)
+        {
+            xHigh++;
+        }
+        else if (xHigh == nx - 1)
+        {
+            xLow--;
+        }
+    }
+   
+    if (yHigh == yLow)
+    {
+        if (yHigh == 0)
+        {
+            yHigh++;
+        }
+        else if (yHigh == ny - 1)
+        {
+            yLow--;
+        }
+    }
+
+
+    Type m1;
+    Type m2;
+    Type f1;
+    Type f2;
+    Type fi;
+
+    if (ny > 1)
+    {
+        // First, interpolate in x.
+        if (nx > 1)
+        {
+            m1 = (f[xHigh][yLow]  - f[xLow][yLow])  / (x[xHigh] - x[xLow]);
+            m2 = (f[xHigh][yHigh] - f[xLow][yHigh]) / (x[xHigh] - x[xLow]);
+
+            f1 = f[xLow][yLow]  + (m1 * (xi - x[xLow]));
+            f2 = f[xLow][yHigh] + (m2 * (xi - x[xLow]));
+        }
+        else
+        {
+            f1 = f[xLow][yLow];
+            f2 = f[xLow][yHigh];
+        }
+
+        // Then, interpolate in y.
+        Type n = (f2 - f1) / (y[yHigh] - y[yLow]);
+
+        fi = f1 + (n * (yi - y[yLow]));
+    }
+    else
+    {
+        // Interpolate in x only.
+        if (nx > 1)
+        {
+            m1 = (f[xHigh][yLow] - f[xLow][yLow]) / (x[xHigh] - x[xLow]);
+            fi = f[xLow][yLow] + (m1 * (xi - x[xLow]));
+        }
+        else
+        {
+            fi = f[xLow][yLow];
+        }
+    }
+
+    return fi;
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/src/ABLForcing/interpolate2D/interpolate2D.H
+++ b/src/ABLForcing/interpolate2D/interpolate2D.H
@@ -1,0 +1,104 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+InNamespace
+    Foam
+
+Description
+    Interpolates function values from a surface to a given point on the 
+    surface using bilinear interpolation.
+
+SourceFiles
+    interpolate2D.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef interpolate2D_H
+#define interpolate2D_H
+
+#include "scalar.H"
+#include "primitiveFieldsFwd.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+template<class Type>
+List<List<Type> > interpolate2D
+(
+    const List<scalar>& xi,
+    const List<scalar>& yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+);
+
+template<class Type>
+List<Type> interpolate2D
+(
+    const scalar& xi,
+    const List<scalar>& yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+);
+
+template<class Type>
+List<Type> interpolate2D
+(
+    const List<scalar>& xi,
+    const scalar& yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+);
+
+template<class Type>
+Type interpolate2D
+(
+    const scalar xi,
+    const scalar yi,
+    const List<scalar>& x,
+    const List<scalar>& y,
+    const List<List<Type> >& f
+);
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+#   include "interpolate2D.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/ABLForcing/spongeLayer/spongeLayer.C
+++ b/src/ABLForcing/spongeLayer/spongeLayer.C
@@ -1,0 +1,231 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "spongeLayer.H"
+
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(spongeLayer, 0);
+}
+
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+void Foam::spongeLayer::update()
+{
+    // Compute the sponge layer damping force
+    if (type_ == "Rayleigh")
+    {
+        bodyForce_ = viscosity_ * (Uref_ - U_);
+    }
+    else if (type_ == "viscous")
+    {
+        bodyForce_ = fvc::laplacian(viscosity_,U_);
+    }
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::spongeLayer::spongeLayer
+(
+    const word& name,
+    const volVectorField& U
+)
+:
+    // Set name
+    name_(name),
+
+    // Set the pointer to runTime
+    runTime_(U.time()),
+
+    // Set the pointer to the mesh
+    mesh_(U.mesh()),
+
+    // Set the pointer to the velocity field
+    U_(U),
+
+    // Initialize the reference velocity field
+    Uref_
+    (
+        IOobject
+        (
+            name_ & "Uref",
+            runTime_.constant(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        dimensionedVector("Uref_", dimensionSet(0, 1, -1, 0, 0, 0, 0), vector::zero)
+    ),
+
+    // Initialize the viscosity field
+    viscosity_
+    (
+        IOobject
+        (
+            name_ & "viscosity",
+            runTime_.timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh_,
+        dimensionedScalar("viscosity_", dimensionSet(0, 0, -1, 0, 0, 0, 0), 0.0)
+    ),
+
+    // Initialize the body force field
+    bodyForce_
+    (
+        IOobject
+        (
+            name_ & "force",
+            runTime_.timeName(),
+            mesh_,
+            IOobject::NO_READ,
+            IOobject::NO_WRITE
+        ),
+        mesh_,
+        dimensionedVector("bodyForce",dimensionSet(0, 1, -2, 0, 0, 0, 0),vector::zero)
+    )
+
+
+{
+    // Define dictionary with input data
+    IOdictionary ABLProperties
+    (
+        IOobject
+        (
+            "ABLProperties",
+            runTime_.time().constant(),
+            runTime_,
+            IOobject::MUST_READ,
+            IOobject::NO_WRITE
+        )
+    );
+    
+    const dictionary& spongeDict(ABLProperties.subOrEmptyDict(name_));
+
+    type_ = spongeDict.lookupOrDefault<word>("type","none");
+
+    // Sponge layer start location
+    scalar startLocation = spongeDict.lookupOrDefault<scalar>("startLocation",0.0);
+
+    // Sponge layer width
+    scalar width = spongeDict.lookupOrDefault<scalar>("width",10000.0);
+
+    // Maximum viscosity
+    scalar viscosityMax = spongeDict.lookupOrDefault<scalar>("viscosityMax",0.0); 
+    
+    // Coordinate index
+    label coordIndex = spongeDict.lookupOrDefault<label>("coordIndex",2);
+
+    // Step up or step down
+    word direction = spongeDict.lookupOrDefault<word>("direction","stepUp");
+
+    // Create sponge layer reference velocity
+    scalar Ux = spongeDict.lookupOrDefault<scalar>("Ux",0.0);
+    scalar Uy = spongeDict.lookupOrDefault<scalar>("Uy",0.0);
+    vector Uref;
+    Uref.x() = Ux;
+    Uref.y() = Uy;
+    Uref.z() = 0.0;
+
+    Uref_ = dimensionedVector("Uref", dimensionSet(0, 1, -1, 0, 0, 0, 0), Uref);
+    
+    if (type_ == "Rayleigh" || type_ == "viscous")
+    {
+        Info << "Adding " << name << " layer (" << type_ << " damping) in coordinate direction " << coordIndex;
+        Info << " between " << startLocation << " and " << startLocation+width << " (" << direction;
+        Info << ") with lambdaMax " << viscosityMax << endl;
+    }
+
+    // For a viscous type sponge layer, change the dimensions of the viscosity field from 1/s to m^2/s
+    if (type_ == "viscous")
+    {
+        viscosity_.dimensions().reset(dimensionSet(0, 2, -1, 0, 0, 0, 0));
+    }
+    
+    // Set viscosity to cosine profile between startLocation and startLocation+width,
+    // For step up:   zero below startLocation and one  above startLocation+width
+    // For step down: one  below startLocation and zero above startLocation+width
+    scalar fact = 1.0; //stepUp
+    if (direction == "stepDown")
+    {
+        fact = -1.0;
+    }
+
+    forAll(mesh_.cells(),cellI)
+    {
+        scalar loc = mesh_.C()[cellI][coordIndex];
+        viscosity_[cellI]  = (loc<=startLocation) * (1.0 - fact);
+        viscosity_[cellI] += ((loc>startLocation) && (loc<startLocation+width)) *
+            (
+                1.0 - fact * Foam::cos
+                    (
+                        Foam::constant::mathematical::pi * (loc - startLocation)/width
+                    )
+
+            );
+        viscosity_[cellI] += (loc>=startLocation+width) * (1.0 + fact);
+        viscosity_[cellI] *= 0.5 * viscosityMax;
+
+    }
+
+    forAll(viscosity_.boundaryField(),i)
+    {
+        if ( !mesh_.boundary()[i].coupled() )
+        {
+            forAll(viscosity_.boundaryField()[i],j)
+            {
+                scalar loc = mesh_.boundary()[i].Cf()[j][coordIndex];
+                viscosity_.boundaryFieldRef()[i][j]  = (loc<=startLocation) * (1.0 - fact);
+                viscosity_.boundaryFieldRef()[i][j] += ((loc>startLocation) && (loc<startLocation+width)) *
+                    (
+                        1.0 - fact * Foam::cos
+                            (
+                                Foam::constant::mathematical::pi * (loc - startLocation)/width
+                            )
+
+                    );
+                viscosity_.boundaryFieldRef()[i][j] += (loc>=startLocation+width) * (1.0 + fact);
+                viscosity_.boundaryFieldRef()[i][j] *= 0.5 * viscosityMax;
+            }
+        }
+    }
+
+
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::spongeLayer::~spongeLayer()
+{}
+
+
+// ************************************************************************* //

--- a/src/ABLForcing/spongeLayer/spongeLayer.H
+++ b/src/ABLForcing/spongeLayer/spongeLayer.H
@@ -1,0 +1,128 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::spongeLayer
+
+Description
+    Sponge layer for damping out vertically propagating gravity waves
+    Possible sponge layer types are "Rayleigh", "viscous" or "none".
+    - The "Rayleigh" type means that the damping term is computed as nu*(u_ref-u)
+      The viscosity coefficient nu has dimensions of 1/s
+    - The "viscous" type means that the damping term is computed as nu * Lapl(u)
+      The viscosity coefficient nu has dimensions of m**2/s
+    - The "none" type means no damping is added
+
+SourceFiles
+    spongeLayer.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef spongeLayer_H
+#define spongeLayer_H
+
+#include "fvCFD.H"
+#include "IOdictionary.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Forward declaration of classes
+
+/*---------------------------------------------------------------------------*\
+                           Class spongeLayer Declaration
+\*---------------------------------------------------------------------------*/
+
+class spongeLayer
+{
+    // Private data
+
+        //- Constants
+            //- Name
+            const word name_;
+
+            //- Runtime pointer
+            const Time& runTime_;
+    
+            //- Mesh pointer
+            const fvMesh& mesh_;
+    
+            //- Velocity field pointer
+            const volVectorField& U_;
+
+        //- Type of sponge layer
+        word type_;
+
+        //- Reference velocity field
+        uniformDimensionedVectorField Uref_;
+
+        //- Viscosity field
+        volScalarField viscosity_;
+
+        //- Body force field of the sponge layer
+        volVectorField bodyForce_;
+
+
+public:
+
+    //- Declare name of the class and its debug switch
+    ClassName("spongeLayer");
+
+
+    // Constructors
+    spongeLayer
+    (
+        const word& name,
+        const volVectorField& U
+    );
+
+
+    // Destructor
+    virtual ~spongeLayer();
+
+
+    // Public Member functions
+
+        //- Update sponge layer force
+        void update();
+
+        //- Return force
+        volVectorField& force()
+        {
+            return bodyForce_;
+        }
+
+
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/ABLForcing/windRoseToCartesian/windRoseToCartesian.C
+++ b/src/ABLForcing/windRoseToCartesian/windRoseToCartesian.C
@@ -1,0 +1,114 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "windRoseToCartesian.H"
+#include "primitiveFields.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+List<List<vector> > windRoseToCartesian
+(
+    const List<List<scalar> >& speed,
+    const List<List<scalar> >& direction
+)
+{
+    // Get size of interpolation point lists.
+    label ni = speed.size();
+    label nj = speed[0].size();
+
+    // Interpolate element by element.
+    List<List<vector> > u(ni,List<vector>(nj));
+    forAll(speed, i)
+    {
+        forAll(speed[i], j)
+        {
+            u[i][j] = windRoseToCartesian(speed[i][j],direction[i][j]);
+        }
+    }
+    return u;
+}
+
+
+List<vector> windRoseToCartesian
+(
+    const List<scalar>& speed,
+    const List<scalar>& direction
+)
+{
+    // Get size of interpolation point lists.
+    label ni = speed.size();
+
+    // Interpolate element by element.
+    List<vector> u(ni);
+    forAll(u, i)
+    {
+        u[i] = windRoseToCartesian(speed[i],direction[i]);
+    }
+    return u;
+}
+
+
+vector windRoseToCartesian
+(
+    const scalar speed,
+    const scalar direction
+)
+{
+    scalar dir = 1.0*direction;
+
+    if (dir > 180.0)
+    {
+       dir -= 180.0;
+    }
+    else
+    {
+       dir += 180.0;
+    }
+    dir = 90.0 - dir;
+    if (dir < 0.0)
+    {
+       dir += 360.0;
+    }
+    dir *= ((Foam::constant::mathematical::pi)/180.0);
+
+    vector u;
+    u.x() = speed * Foam::cos(dir);
+    u.y() = speed * Foam::sin(dir);
+    u.z() = 0.0;
+
+    return u;
+}
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// ************************************************************************* //

--- a/src/ABLForcing/windRoseToCartesian/windRoseToCartesian.H
+++ b/src/ABLForcing/windRoseToCartesian/windRoseToCartesian.H
@@ -1,0 +1,82 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+InNamespace
+    Foam
+
+Description
+    Interpolates function values from a surface to a given point on the 
+    surface using bilinear interpolation.
+
+SourceFiles
+    windRoseToCartesian.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef windRoseToCartesian_H
+#define windRoseToCartesian_H
+
+//#include "scalar.H"
+#include "primitiveFieldsFwd.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+List<List<vector> > windRoseToCartesian
+(
+    const List<List<scalar> >& speed,
+    const List<List<scalar> >& direction
+);
+
+List<vector> windRoseToCartesian
+(
+    const List<scalar>& speed,
+    const List<scalar>& direction
+);
+
+vector windRoseToCartesian
+(
+    const scalar speed,
+    const scalar direction
+);
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#ifdef NoRepository
+#   include "windRoseToCartesian.C"
+#endif
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/meshTools/Make/files
+++ b/src/meshTools/Make/files
@@ -1,0 +1,3 @@
+meshPlanes/meshPlanes.C
+
+LIB = $(SOWFA_DIR)/lib/$(WM_OPTIONS)/libSOWFAmeshTools

--- a/src/meshTools/Make/options
+++ b/src/meshTools/Make/options
@@ -1,0 +1,7 @@
+EXE_INC = \
+    -I$(LIB_SRC)/meshTools/lnInclude \
+    -I$(LIB_SRC)/finiteVolume/lnInclude
+
+LIB_LIBS = \
+    -lfiniteVolume \
+    -lmeshTools

--- a/src/meshTools/meshPlanes/meshPlanes.C
+++ b/src/meshTools/meshPlanes/meshPlanes.C
@@ -1,0 +1,379 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011-2013 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+#include "meshPlanes.H"
+
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+    defineTypeNameAndDebug(meshPlanes, 0);
+    
+    scalar meshPlanes::tol_ = 1.0E-8;
+}
+
+
+// * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
+
+void Foam::meshPlanes::findPlanes()
+{
+
+    // On each processor, do a search through all cells and make a list of 
+    // all distinct plane locations
+
+    DynamicList<scalar> planeLocationValuesP(0);
+    numberOfPlanes_ = 0;
+
+    forAll(mesh_.cells(),cellI)
+    {
+	    const vector& cellCenter = mesh_.C()[cellI];
+    	int planesFlag = 0;
+        if(cellI == 0)
+	    {
+	        planeLocationValuesP.append(cellCenter[normalIndex_]);
+	        numberOfPlanes_++;
+	    }
+	    else
+	    {
+	        forAll(planeLocationValuesP,planeI)
+	        {
+	            const scalar loc = planeLocationValuesP[planeI];
+		        if(mag(cellCenter[normalIndex_] - loc) < tol_)
+		        {
+                    planesFlag = 1;
+		        }
+	        }
+	        if(planesFlag == 0)
+	        {
+	            planeLocationValuesP.append(cellCenter[normalIndex_]);
+		        numberOfPlanes_++;
+	        }
+	    }
+    }
+    reduce(numberOfPlanes_,sumOp<label>());
+
+
+    // Now combine the plane location lists from each processor on the master
+    List<List<scalar> > planeLocationValuesM(Pstream::nProcs());
+    planeLocationValuesM[Pstream::myProcNo()] = planeLocationValuesP;
+    Pstream::gatherList(planeLocationValuesM);
+    Pstream::scatterList(planeLocationValuesM);
+
+
+
+    // Remove duplicate values in the list of plane locations
+    DynamicList<scalar> planeLocationValues_Unsrt;
+    {
+        label I = 0;
+        numberOfPlanes_ = 0;
+        forAll(planeLocationValuesM,ListI)
+        {
+            forAll(planeLocationValuesM[ListI],ListJ)
+            {
+	            label planesFlag = 0;
+	            if(I == 0)
+	            {
+	                planeLocationValues_Unsrt.append(planeLocationValuesM[ListI][ListJ]);
+		            numberOfPlanes_++;
+	            }
+	            else
+	            {
+	                for(label J = 0; J < numberOfPlanes_; J++)
+	                {
+	                    const scalar loc = planeLocationValues_Unsrt[J];
+	                    if(mag(planeLocationValuesM[ListI][ListJ] - loc) < tol_)
+	  	                {
+		                    planesFlag = 1;
+		                }
+	                }
+	                if(planesFlag == 0)
+	                {
+	                    planeLocationValues_Unsrt.append(planeLocationValuesM[ListI][ListJ]);
+		                numberOfPlanes_++;
+	                }
+                }
+                I++;
+           }
+        }
+    }
+    planeLocationValues_ = planeLocationValues_Unsrt;
+    //Info << endl << "Plane Location Values: " << planeLocationValues_ << endl;
+
+
+    // Sort the height list to be in ascending order
+    forAll(planeLocationValues_,planeI)
+    {
+	    scalar planeLocationValuesMin = 1.0E20;
+    	scalar locValue = 0.0;
+	    label locLabelJ = 0;
+	    for(int planeJ = planeI; planeJ < numberOfPlanes_; planeJ++)
+	    {
+            if(planeLocationValues_[planeJ] < planeLocationValuesMin)
+	        {
+	            locValue = planeLocationValues_[planeJ];
+		        locLabelJ = planeJ;
+		        planeLocationValuesMin = locValue;
+	        }
+	    }
+    	planeLocationValues_[locLabelJ] = planeLocationValues_[planeI];
+	    planeLocationValues_[planeI] = locValue;
+    }
+
+
+    // Make a list of lists of cell ID labels.  Each list within the list contains
+    // the cell ID labels corresponding to a specific plane on a processor.  The overall list
+    // should contain as many cell ID labels lists as there are distinct planes.
+    // Also sum up the volume of cells in each plane on each processor.
+    List<scalar> totVolPerPlaneP(numberOfPlanes_);
+   
+    forAll(planeLocationValues_,planeI)
+    {
+	    numCellPerPlane_.append(0);
+	    totVolPerPlaneP[planeI] = 0.0;
+        forAll(mesh_.cells(),cellI)
+        {
+            const vector& cellCenter = mesh_.C()[cellI];
+	        if(mag(cellCenter[normalIndex_] - planeLocationValues_[planeI]) < tol_)
+	        {
+	            numCellPerPlane_[planeI]++;
+		        totVolPerPlaneP[planeI] += mesh_.V()[cellI];
+	        }
+	    }
+    }
+
+    forAll(planeLocationValues_,planeI)
+    {
+        //planesCellList_.append(List<label>(max(numCellPerPlane_)));
+        planesCellList_.append(List<label>(numCellPerPlane_[planeI]));
+	    int i = 0;
+        forAll(mesh_.cells(),cellI)
+	    {
+	        const vector& cellCenter = mesh_.C()[cellI];
+	        if(mag(cellCenter[normalIndex_] - planeLocationValues_[planeI]) < tol_)
+	        {
+        		planesCellList_[planeI][i] = cellI;
+		        i++;
+    	    }
+	    }
+    }
+
+    // Gather the volumes per plane to get a global value
+    List<List<scalar> > totVolPerPlaneM(Pstream::nProcs());
+    totVolPerPlaneM[Pstream::myProcNo()] = totVolPerPlaneP;
+    Pstream::gatherList(totVolPerPlaneM);
+    Pstream::scatterList(totVolPerPlaneM);
+    
+    forAll(planeLocationValues_,planeI)
+    {
+        totVolPerPlane_.append(0.0);
+    	for (int n = 0; n < Pstream::nProcs(); n++)
+	    {
+            totVolPerPlane_[planeI] += totVolPerPlaneM[n][planeI];
+        }
+    }
+
+
+//    forAll(numCellPerPlane_,i)
+//    {
+//        label numCellPerPlaneGlobal = numCellPerPlane_[i];
+//        reduce(numCellPerPlaneGlobal,sumOp<label>());
+//    }
+
+}
+
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::meshPlanes::meshPlanes
+(
+    const fvMesh& mesh,
+    const word& normal
+)
+:
+    mesh_(mesh)
+{
+
+    if (normal == "x")
+    {
+        normalIndex_ = 0;
+    }
+    else if (normal == "y")
+    {
+        normalIndex_ = 1;
+    }
+    else if (normal == "z")
+    {
+        normalIndex_ = 2;
+    }
+
+
+    findPlanes();
+
+    Info << "number of meshPlanes: " << numberOfPlanes_ << endl;
+    Info << totVolPerPlane_ << endl;
+
+}
+
+
+Foam::meshPlanes::meshPlanes
+(
+    const fvMesh& mesh
+)
+:
+    mesh_(mesh)
+{
+    // Default to z planes
+    normalIndex_ = 2;
+
+    findPlanes();
+}
+
+
+// * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
+
+Foam::meshPlanes::~meshPlanes()
+{}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+
+template<class Type>
+List<Type> Foam::meshPlanes::average
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vField
+)
+{
+    List<Type> vFieldMean(numberOfPlanes_,Type::zero);
+
+    forAll(planeLocationValues_,planeI)
+    {
+        for (label i = 0; i < numCellPerPlane_[planeI]; i++)
+        {
+            label cellI = planesCellList_[planeI][i];
+            vFieldMean[planeI] += vField[cellI] * mesh_.V()[cellI];
+        }
+    }
+
+    reduce(vFieldMean,sumOp<List<Type> >());
+
+    forAll(planeLocationValues_,planeI)
+    {
+        vFieldMean[planeI] /= totVolPerPlane_[planeI];
+    }
+
+    return vFieldMean;
+}
+
+
+template<class Type>
+Type Foam::meshPlanes::average
+(
+    const GeometricField<Type, fvPatchField, volMesh>& vField,
+    label planeI
+)
+{
+    Type vFieldMean(Type::zero);
+
+    for (label i = 0; i < numCellPerPlane_[planeI]; i++)
+    {
+        label cellI = planesCellList_[planeI][i];
+        vFieldMean += vField[cellI] * mesh_.V()[cellI];
+    }
+
+    reduce(vFieldMean,sumOp<Type>());
+
+    vFieldMean /= totVolPerPlane_[planeI];
+
+    return vFieldMean;
+}
+
+
+// Explicit instantiation of template function average<Type>
+template vector Foam::meshPlanes::average<vector>(const volVectorField&, label);
+template List<vector> Foam::meshPlanes::average<vector>(const volVectorField&);
+template symmTensor Foam::meshPlanes::average<symmTensor>(const volSymmTensorField&, label);
+template List<symmTensor> Foam::meshPlanes::average<symmTensor>(const volSymmTensorField&);
+
+// Specialization for average<scalar>
+// Reason: scalar::zero does not exist, so initialization must use 0.0 instead
+// Note that template specialization must be within Foam namespace,
+// and providing the namespace as part of the type does not work in this case.
+namespace Foam
+{
+    template<>
+    List<scalar> meshPlanes::average<scalar>
+    (
+        const GeometricField<scalar, fvPatchField, volMesh>& vField
+    )
+    {
+        List<scalar> vFieldMean(numberOfPlanes_,0.0);
+    
+        forAll(planeLocationValues_,planeI)
+        {
+            for (label i = 0; i < numCellPerPlane_[planeI]; i++)
+            {
+                label cellI = planesCellList_[planeI][i];
+                vFieldMean[planeI] += vField[cellI] * mesh_.V()[cellI];
+            }
+        }
+    
+        reduce(vFieldMean,sumOp<List<scalar> >());
+    
+        forAll(planeLocationValues_,planeI)
+        {
+            vFieldMean[planeI] /= totVolPerPlane_[planeI];
+        }
+    
+        return vFieldMean;
+    }
+
+
+    template<>
+    scalar meshPlanes::average<scalar>
+    (
+        const GeometricField<scalar, fvPatchField, volMesh>& vField,
+        label planeI
+    )
+    {
+        scalar vFieldMean(0.0);
+    
+        for (label i = 0; i < numCellPerPlane_[planeI]; i++)
+        {
+            label cellI = planesCellList_[planeI][i];
+            vFieldMean += vField[cellI] * mesh_.V()[cellI];
+        }
+    
+        reduce(vFieldMean,sumOp<scalar>());
+    
+        vFieldMean /= totVolPerPlane_[planeI];
+    
+        return vFieldMean;
+    }
+}
+
+
+// ************************************************************************* //

--- a/src/meshTools/meshPlanes/meshPlanes.H
+++ b/src/meshTools/meshPlanes/meshPlanes.H
@@ -1,0 +1,184 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2011 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::meshPlanes
+
+Description
+    Data structure containing a set of planes in a given direction
+
+SourceFiles
+    meshPlanes.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef meshPlanes_H
+#define meshPlanes_H
+
+#include "fvCFD.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+// Forward declaration of classes
+
+/*---------------------------------------------------------------------------*\
+                           Class meshPlanes Declaration
+\*---------------------------------------------------------------------------*/
+
+class meshPlanes
+{
+    // Private data
+
+        //- Index corresponding to the normal to the planes
+        label normalIndex_;
+
+        //- Reference to mesh
+        const fvMesh& mesh_;
+
+        //- Total number of planes
+        label numberOfPlanes_;
+
+        //- Total volume per plane (global value)
+        List<scalar> totVolPerPlane_;
+
+        //- List of lists of cell ID labels corresponding to a specific plane on a processor
+        List<List<label> > planesCellList_;
+
+        //- Number of cells per plane on a processor
+        labelList numCellPerPlane_;
+
+        //- List of plane locations
+        List<scalar> planeLocationValues_;
+
+
+    // Private Member Functions
+
+        //- Find cells per plane 
+        void findPlanes();
+
+
+public:
+
+    //- Declare name of the class and its debug switch
+    ClassName("meshPlanes");
+
+
+    // Static member data
+
+        //- tolerance on plane locations
+        static scalar tol_;
+
+
+    // Constructors
+
+        //- Construct from components
+        meshPlanes
+        (
+            const fvMesh& mesh,
+            const word& normal
+        );
+
+        //- Construct default (z-planes)
+        meshPlanes
+        (
+            const fvMesh& mesh
+        );
+
+
+    // Destructor
+    virtual ~meshPlanes();
+
+
+    // Member functions
+
+        //- Compute planar average
+        template<class Type>
+        List<Type> average
+        (
+            const GeometricField<Type, fvPatchField, volMesh>& vField
+        );
+
+        //- Compute planar average at particular plane
+        template<class Type>
+        Type average
+        (
+            const GeometricField<Type, fvPatchField, volMesh>& vField,
+            label planeI
+        );
+
+        //- Access
+        
+            label numberOfPlanes() const
+            {
+                return numberOfPlanes_;
+            }
+    
+            List<scalar>& totVolPerPlane()
+            {
+                return totVolPerPlane_;
+            }
+    
+            List<List<label> >& planesCellList()
+            {
+                return planesCellList_;
+            }
+    
+            labelList& numCellPerPlane()
+            {
+                return numCellPerPlane_;
+            }
+    
+            List<scalar>& planeLocationValues()
+            {
+                return planeLocationValues_;
+            }
+
+
+};
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+//- Loop across all planes in \a meshPlanes
+// \par Usage
+// \code
+// forAllPlanes(meshPlanes, i)
+// {
+//      statements;
+// }
+// \endcode
+// \sa forAllPlanes
+#define forAllPlanes(meshPlanes, i) \
+    for (Foam::label i=0; i<(meshPlanes).numberOfPlanes(); i++)
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //


### PR DESCRIPTION
The meshTools and ABLForcing libraries, originally developed for SOWFA-2.4.x, are made compatible with SOWFA-6, and both libraries are added to the SOWFA distribution. The new solver buoyantBoussinesqPimpleFoam is extended with the ABLForcing/drivingForce class. 