### PR TITLE
Correct length scale calculation and other bugs in kEpsilonABL

### DIFF
--- a/src/turbulenceModels/incompressible/RAS/kEpsilonABL/kEpsilonABL.H
+++ b/src/turbulenceModels/incompressible/RAS/kEpsilonABL/kEpsilonABL.H
@@ -94,9 +94,7 @@ protected:
             dimensionedScalar sigmak_;
             dimensionedScalar sigmaEps_;
             dimensionedScalar kappa_;
-            dimensionedScalar lambda_;
             dimensionedScalar lmax_;
-            dimensionedScalar L_;
             volScalarField alphaB_;
             volScalarField Ceps1Star_;
             volScalarField Ceps3_;
@@ -113,8 +111,6 @@ protected:
         // Other necessary information.
             IOdictionary transportDict_;
             word TName_;
-            word RwallName_;
-            word qwallName_;
             const volScalarField& T_;
             const uniformDimensionedVectorField& g_;
             dimensionedScalar TRef_;
@@ -146,8 +142,8 @@ public:
 
 
     // Member Functions
-        //- Compute the stability-dependent length scale
-        virtual void computeLengthScale();
+        //- Compute the maximum length scale
+        virtual void computeMaxLengthScale();
 
         //- Return the turbulence viscosity
         virtual tmp<volScalarField> nut() const


### PR DESCRIPTION
1. lm is calculated with k and epsilon instead of using an analytical function
2. denominator of lmax should be max() instead of min()
3. Richardson number should be -B/P such that Ri<0 corresponds to unstable conditions