### PR TITLE
Replace unified solver buoyancy model by buoyancy class object

### DIFF
--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/Make/options
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/Make/options
@@ -9,7 +9,8 @@ EXE_INC = \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/finiteVolume/lnInclude \
     -I$(SOWFA_DIR)/src/ABLForcing/lnInclude \
-    -I$(SOWFA_DIR)/src/meshTools/lnInclude
+    -I$(SOWFA_DIR)/src/meshTools/lnInclude \
+    -I../commonAlgorithms
 
 EXE_LIBS = \
     -L$(SOWFA_DIR)/lib/$(WM_OPTIONS) \

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/TEqn.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/TEqn.H
@@ -2,7 +2,7 @@
     kappat = turbulence->nut()/Prt;
     kappat.correctBoundaryConditions();
 
-    volScalarField kappaEff("alphaEff", turbulence->nu()/Pr + kappat);
+    volScalarField kappaEff("kappaEff", turbulence->nu()/Pr + kappat);
 
     fvScalarMatrix TEqn
     (
@@ -26,5 +26,5 @@
 
     fvOptions.correct(T);
 
-    rhok = 1.0 - beta*(T - TRef);
+    Boussinesq.updateDensityField();
 }

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/UEqn.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/UEqn.H
@@ -3,6 +3,9 @@
     // Update Coriolis forcing
     Coriolis.update();
 
+    // Update buoyancy term
+    Boussinesq.updateBuoyancyTerm();
+
     MRF.correctBoundaryVelocity(U);
 
     fvVectorMatrix UEqn
@@ -30,8 +33,8 @@
             fvc::reconstruct
             (
                 (
-                  - ghf*fvc::snGrad(rhok)
                   - fvc::snGrad(p_rgh)
+                  + Boussinesq.buoyancyTerm()
                 )*mesh.magSf()
             )
         );

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/createFields.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/createFields.H
@@ -59,18 +59,6 @@ CoriolisForce Coriolis(U);
 DrivingForce<scalar> temperatureSourceTerm("temperature",T);
 DrivingForce<vector> momentumSourceTerm("momentum",U);
 
-// Kinematic density for buoyancy force
-volScalarField rhok
-(
-    IOobject
-    (
-        "rhok",
-        runTime.timeName(),
-        mesh
-    ),
-    1.0 - beta*(T - TRef)
-);
-
 // kinematic turbulent thermal thermal conductivity m2/s
 Info<< "Reading field kappat\n" << endl;
 volScalarField kappat
@@ -118,8 +106,6 @@ volVectorField qwall
 
 
 #include "readGravitationalAcceleration.H"
-#include "readhRef.H"
-#include "gh.H"
 
 
 volScalarField p
@@ -132,7 +118,7 @@ volScalarField p
         IOobject::NO_READ,
         IOobject::AUTO_WRITE
     ),
-    p_rgh + rhok*gh
+    p_rgh
 );
 
 label pRefCell = 0;
@@ -146,15 +132,18 @@ setRefCell
     pRefValue
 );
 
-if (p_rgh.needReference())
+// Create buoyancy model
+vector hRef_ = vector::zero;
+if (pRefCell != -1)
 {
-    p += dimensionedScalar
-    (
-        "p",
-        p.dimensions(),
-        pRefValue - getRefCellValue(p, pRefCell)
-    );
+    hRef_ = mesh.C()[pRefCell];
 }
+reduce(hRef_,sumOp<vector>());
+dimensionedVector hRef("hRef",dimLength,hRef_);
+    
+buoyancyModel Boussinesq(T, TRef, hRef);
+
+#include "adjustPressureLevel.H"
 
 mesh.setFluxRequired(p_rgh.name());
 

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/pEqn.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/pEqn.H
@@ -3,7 +3,8 @@
     surfaceScalarField rAUf("rAUf", fvc::interpolate(rAU));
     volVectorField HbyA(constrainHbyA(rAU*UEqn.H(), U, p_rgh));
 
-    surfaceScalarField phig(-rAUf*ghf*fvc::snGrad(rhok)*mesh.magSf());
+    Boussinesq.updateBuoyancyTerm();
+    surfaceScalarField phig(rAUf * Boussinesq.buoyancyTerm() * mesh.magSf());
 
     surfaceScalarField phiHbyA
     (
@@ -47,16 +48,5 @@
 
     #include "continuityErrs.H"
 
-    p = p_rgh + rhok*gh;
-
-    if (p_rgh.needReference())
-    {
-        p += dimensionedScalar
-        (
-            "p",
-            p.dimensions(),
-            pRefValue - getRefCellValue(p, pRefCell)
-        );
-        p_rgh = p - rhok*gh;
-    }
+    #include "adjustPressureLevel.H"
 }

--- a/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/readTransportProperties.H
+++ b/applications/solvers/incompressible/windEnergy/buoyantBoussinesqPimpleFoam/readTransportProperties.H
@@ -1,13 +1,5 @@
 singlePhaseTransportModel laminarTransport(U, phi);
 
-// Thermal expansion coefficient [1/K]
-dimensionedScalar beta
-(
-    "beta",
-    dimless/dimTemperature,
-    laminarTransport
-);
-
 // Reference temperature [K]
 dimensionedScalar TRef("TRef", dimTemperature, laminarTransport);
 

--- a/applications/solvers/incompressible/windEnergy/commonAlgorithms/adjustPressureLevel.H
+++ b/applications/solvers/incompressible/windEnergy/commonAlgorithms/adjustPressureLevel.H
@@ -1,16 +1,6 @@
     // Compute the full pressure and adjust the pressure level.
-    if (perturbationPressureType == "noSplit")
-    {
-        p = p_rgh;
-    }
-    else if (perturbationPressureType == "rho0Split")
-    {
-        p = p_rgh + gh;
-    }
-    else if (perturbationPressureType == "rhokSplit")
-    {
-        p = p_rgh + rhok*gh;
-    }
+    Boussinesq.updateBackgroundPressure();
+    p = p_rgh + Boussinesq.backgroundPressure();
 
     if (p_rgh.needReference())
     {
@@ -21,16 +11,5 @@
             pRefValue - getRefCellValue(p, pRefCell)
         );
 
-        if (perturbationPressureType == "noSplit")
-        {
-           p_rgh = p;
-        }
-        else if (perturbationPressureType == "rho0Split")
-        {
-           p_rgh = p - gh;
-        }
-        else if (perturbationPressureType == "rhokSplit")
-        {
-           p_rgh = p - rhok*gh;
-        }
+        p_rgh = p - Boussinesq.backgroundPressure();
     }


### PR DESCRIPTION
The standard buoyancy model in buoyantBoussinesqPimpleFoam is replaced by a buoyancy class object, which offers different ways to split the pressure into perturbation pressure and hydrostatic background pressure (based on rho_0 or rho_k).